### PR TITLE
Rename purchase to mint

### DIFF
--- a/src/interfaces/IZoraCreator1155.sol
+++ b/src/interfaces/IZoraCreator1155.sol
@@ -51,12 +51,12 @@ interface IZoraCreator1155 is IZoraCreator1155TypesV1, IVersionedContract {
     ) external;
 
     /// @notice Only allow minting one token id at time
-    /// @dev Purchase contract function that calls the underlying sales function for commands
+    /// @dev Mint contract function that calls the underlying sales function for commands
     /// @param minter Address for the minter
     /// @param tokenId tokenId to mint, set to 0 for new tokenId
-    /// @param quantity to purchase
+    /// @param quantity to mint
     /// @param minterArguments calldata for the minter contracts
-    function purchase(IMinter1155 minter, uint256 tokenId, uint256 quantity, bytes calldata minterArguments) external payable;
+    function mint(IMinter1155 minter, uint256 tokenId, uint256 quantity, bytes calldata minterArguments) external payable;
 
     function adminMint(address recipient, uint256 tokenId, uint256 quantity, bytes memory data) external;
 

--- a/src/nft/ZoraCreator1155Impl.sol
+++ b/src/nft/ZoraCreator1155Impl.sol
@@ -300,12 +300,12 @@ contract ZoraCreator1155Impl is
         _mintBatch(recipient, tokenIds, quantities, data);
     }
 
-    /// @notice Purchase tokens given a minter contract and minter arguments
+    /// @notice Mint tokens given a minter contract and minter arguments
     /// @param minter The minter contract to use
-    /// @param tokenId The token ID to purchase
-    /// @param quantity The quantity of tokens to purchase
+    /// @param tokenId The token ID to mint
+    /// @param quantity The quantity of tokens to mint
     /// @param minterArguments The arguments to pass to the minter
-    function purchase(IMinter1155 minter, uint256 tokenId, uint256 quantity, bytes calldata minterArguments) external payable {
+    function mint(IMinter1155 minter, uint256 tokenId, uint256 quantity, bytes calldata minterArguments) external payable {
         // Require admin from the minter to mint
         _requireAdminOrRole(address(minter), tokenId, PERMISSION_BIT_MINTER);
 

--- a/test/fee/MintFeeManager.t.sol
+++ b/test/fee/MintFeeManager.t.sol
@@ -32,7 +32,7 @@ contract MintFeeManagerTest is Test {
     function test_mintFeeSent(uint32 mintFee, uint256 quantity) external {
         vm.assume(quantity < 100);
         vm.assume(mintFee < 0.1 ether);
-        uint256 purchasePrice = mintFee * quantity;
+        uint256 mintPrice = mintFee * quantity;
         zoraCreator1155Impl = new ZoraCreator1155Impl(mintFee, recipient);
         target = ZoraCreator1155Impl(address(new ZoraCreator1155Proxy(address(zoraCreator1155Impl))));
         adminRole = target.PERMISSION_BIT_ADMIN();
@@ -45,22 +45,22 @@ contract MintFeeManagerTest is Test {
         vm.prank(admin);
         target.addPermission(tokenId, minter, adminRole);
 
-        vm.deal(admin, purchasePrice);
+        vm.deal(admin, mintPrice);
         vm.prank(admin);
-        target.purchase{value: purchasePrice}(SimpleMinter(payable(minter)), tokenId, quantity, abi.encode(recipient));
+        target.mint{value: mintPrice}(SimpleMinter(payable(minter)), tokenId, quantity, abi.encode(recipient));
 
         vm.prank(admin);
         target.withdrawAll();
 
         // Mint fee is not paid if the recipient is address(0)
-        assertEq(recipient.balance, recipient == address(0) ? 0 : purchasePrice);
-        assertEq(admin.balance, recipient == address(0) ? purchasePrice : purchasePrice - (mintFee * quantity));
+        assertEq(recipient.balance, recipient == address(0) ? 0 : mintPrice);
+        assertEq(admin.balance, recipient == address(0) ? mintPrice : mintPrice - (mintFee * quantity));
     }
 
     function test_mintFeeSent_revertCannotSendMintFee(uint32 mintFee, uint256 quantity) external {
         vm.assume(quantity < 100);
 
-        uint256 purchasePrice = mintFee * quantity;
+        uint256 mintPrice = mintFee * quantity;
 
         // Use this mock contract as a recipient so we can reject ETH payments.
         SimpleMinter _recip = new SimpleMinter();
@@ -79,9 +79,9 @@ contract MintFeeManagerTest is Test {
         vm.prank(admin);
         target.addPermission(tokenId, minter, adminRole);
 
-        vm.deal(admin, purchasePrice);
-        vm.expectRevert(abi.encodeWithSelector(IMintFeeManager.CannotSendMintFee.selector, _recipient, purchasePrice));
+        vm.deal(admin, mintPrice);
+        vm.expectRevert(abi.encodeWithSelector(IMintFeeManager.CannotSendMintFee.selector, _recipient, mintPrice));
         vm.prank(admin);
-        target.purchase{value: purchasePrice}(SimpleMinter(payable(minter)), tokenId, quantity, abi.encode(recipient));
+        target.mint{value: mintPrice}(SimpleMinter(payable(minter)), tokenId, quantity, abi.encode(recipient));
     }
 }

--- a/test/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.t.sol
+++ b/test/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.t.sol
@@ -34,7 +34,7 @@ contract ZoraCreatorFixedPriceSaleStrategyTest is Test {
         assertEq(fixedPrice.contractVersion(), "0.0.1");
     }
 
-    function test_PurchaseFlow() external {
+    function test_MintFlow() external {
         vm.startPrank(admin);
         uint256 newTokenId = target.setupNewToken("https://zora.co/testing/token.json", 10);
         target.addPermission(newTokenId, address(fixedPrice), target.PERMISSION_BIT_MINTER());
@@ -71,7 +71,7 @@ contract ZoraCreatorFixedPriceSaleStrategyTest is Test {
         vm.deal(tokenRecipient, 20 ether);
 
         vm.startPrank(tokenRecipient);
-        target.purchase{value: 10 ether}(fixedPrice, newTokenId, 10, abi.encode(tokenRecipient));
+        target.mint{value: 10 ether}(fixedPrice, newTokenId, 10, abi.encode(tokenRecipient));
 
         assertEq(target.balanceOf(tokenRecipient, newTokenId), 10);
         assertEq(address(target).balance, 10 ether);
@@ -105,7 +105,7 @@ contract ZoraCreatorFixedPriceSaleStrategyTest is Test {
 
         vm.expectRevert(abi.encodeWithSignature("SaleHasNotStarted()"));
         vm.prank(tokenRecipient);
-        target.purchase{value: 10 ether}(fixedPrice, newTokenId, 10, abi.encode(tokenRecipient));
+        target.mint{value: 10 ether}(fixedPrice, newTokenId, 10, abi.encode(tokenRecipient));
     }
 
     function test_SaleEnd() external {
@@ -136,7 +136,7 @@ contract ZoraCreatorFixedPriceSaleStrategyTest is Test {
 
         vm.expectRevert(abi.encodeWithSignature("SaleEnded()"));
         vm.prank(tokenRecipient);
-        target.purchase{value: 10 ether}(fixedPrice, newTokenId, 10, abi.encode(tokenRecipient));
+        target.mint{value: 10 ether}(fixedPrice, newTokenId, 10, abi.encode(tokenRecipient));
     }
 
     function test_MaxTokensPerAddress() external {
@@ -167,10 +167,10 @@ contract ZoraCreatorFixedPriceSaleStrategyTest is Test {
 
         vm.prank(tokenRecipient);
         vm.expectRevert(abi.encodeWithSignature("MintedTooManyForAddress()"));
-        target.purchase{value: 6 ether}(fixedPrice, newTokenId, 6, abi.encode(tokenRecipient));
+        target.mint{value: 6 ether}(fixedPrice, newTokenId, 6, abi.encode(tokenRecipient));
     }
 
-    function testFail_setupPurchase() external {
+    function testFail_setupMint() external {
         vm.startPrank(admin);
         uint256 newTokenId = target.setupNewToken("https://zora.co/testing/token.json", 10);
         target.addPermission(newTokenId, address(fixedPrice), target.PERMISSION_BIT_MINTER());
@@ -195,7 +195,7 @@ contract ZoraCreatorFixedPriceSaleStrategyTest is Test {
         vm.deal(tokenRecipient, 20 ether);
 
         vm.startPrank(tokenRecipient);
-        target.purchase{value: 10 ether}(fixedPrice, newTokenId, 10, abi.encode(tokenRecipient));
+        target.mint{value: 10 ether}(fixedPrice, newTokenId, 10, abi.encode(tokenRecipient));
 
         assertEq(target.balanceOf(tokenRecipient, newTokenId), 10);
         assertEq(address(target).balance, 10 ether);
@@ -231,10 +231,10 @@ contract ZoraCreatorFixedPriceSaleStrategyTest is Test {
 
         vm.startPrank(tokenRecipient);
         vm.expectRevert(abi.encodeWithSignature("WrongValueSent()"));
-        target.purchase{value: 0.9 ether}(fixedPrice, newTokenId, 1, abi.encode(tokenRecipient));
+        target.mint{value: 0.9 ether}(fixedPrice, newTokenId, 1, abi.encode(tokenRecipient));
         vm.expectRevert(abi.encodeWithSignature("WrongValueSent()"));
-        target.purchase{value: 1.1 ether}(fixedPrice, newTokenId, 1, abi.encode(tokenRecipient));
-        target.purchase{value: 1 ether}(fixedPrice, newTokenId, 1, abi.encode(tokenRecipient));
+        target.mint{value: 1.1 ether}(fixedPrice, newTokenId, 1, abi.encode(tokenRecipient));
+        target.mint{value: 1 ether}(fixedPrice, newTokenId, 1, abi.encode(tokenRecipient));
         vm.stopPrank();
     }
 
@@ -262,7 +262,7 @@ contract ZoraCreatorFixedPriceSaleStrategyTest is Test {
         address tokenRecipient = address(322);
         vm.deal(tokenRecipient, 20 ether);
         vm.prank(tokenRecipient);
-        target.purchase{value: 10 ether}(fixedPrice, newTokenId, 10, abi.encode(tokenRecipient));
+        target.mint{value: 10 ether}(fixedPrice, newTokenId, 10, abi.encode(tokenRecipient));
 
         assertEq(address(1).balance, 10 ether);
     }

--- a/test/minters/merkle/ZoraCreatorMerkleMinterStrategy.t.sol
+++ b/test/minters/merkle/ZoraCreatorMerkleMinterStrategy.t.sol
@@ -38,7 +38,7 @@ contract ZoraCreatorMerkleMinterStrategyTest is Test {
         assertEq(merkleMinter.contractVersion(), "0.0.1");
     }
 
-    function test_PurchaseFlow() external {
+    function test_MintFlow() external {
         vm.startPrank(admin);
         uint256 newTokenId = target.setupNewToken("https://zora.co/testing/token.json", 10);
         target.addPermission(newTokenId, address(merkleMinter), target.PERMISSION_BIT_MINTER());
@@ -74,7 +74,7 @@ contract ZoraCreatorMerkleMinterStrategyTest is Test {
         merkleProof[0] = bytes32(0x71013e6ce1f439aaa91aa706ddd0769517fbaa4d72a936af4a7c75d29b1ca862);
 
         vm.startPrank(mintTo);
-        target.purchase{value: 10 ether}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
+        target.mint{value: 10 ether}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
 
         assertEq(target.balanceOf(mintTo, newTokenId), 10);
         assertEq(address(target).balance, 10 ether);
@@ -113,7 +113,7 @@ contract ZoraCreatorMerkleMinterStrategyTest is Test {
 
         vm.prank(mintTo);
         vm.expectRevert(abi.encodeWithSignature("SaleHasNotStarted()"));
-        target.purchase{value: 10 ether}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
+        target.mint{value: 10 ether}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
     }
 
     function test_PreSaleEnd() external {
@@ -148,7 +148,7 @@ contract ZoraCreatorMerkleMinterStrategyTest is Test {
 
         vm.prank(mintTo);
         vm.expectRevert(abi.encodeWithSignature("SaleEnded()"));
-        target.purchase{value: 10 ether}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
+        target.mint{value: 10 ether}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
     }
 
     function test_FundsRecipient() external {
@@ -187,7 +187,7 @@ contract ZoraCreatorMerkleMinterStrategyTest is Test {
         merkleProof[0] = bytes32(0x71013e6ce1f439aaa91aa706ddd0769517fbaa4d72a936af4a7c75d29b1ca862);
 
         vm.prank(mintTo);
-        target.purchase{value: 10 ether}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
+        target.mint{value: 10 ether}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
 
         assertEq(address(1234).balance, 10 ether);
     }
@@ -229,7 +229,7 @@ contract ZoraCreatorMerkleMinterStrategyTest is Test {
 
         vm.prank(mintTo);
         vm.expectRevert(abi.encodeWithSignature("InvalidMerkleProof(address,bytes32[],bytes32)", mintTo, merkleProof, root));
-        target.purchase{value: 10 ether}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
+        target.mint{value: 10 ether}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
     }
 
     function test_MaxQuantity() external {
@@ -268,9 +268,9 @@ contract ZoraCreatorMerkleMinterStrategyTest is Test {
         merkleProof[0] = bytes32(0x71013e6ce1f439aaa91aa706ddd0769517fbaa4d72a936af4a7c75d29b1ca862);
 
         vm.startPrank(mintTo);
-        target.purchase{value: 10 ether}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
+        target.mint{value: 10 ether}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
         vm.expectRevert(abi.encodeWithSignature("MintedTooManyForAddress()"));
-        target.purchase{value: 1 ether}(merkleMinter, newTokenId, 1, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
+        target.mint{value: 1 ether}(merkleMinter, newTokenId, 1, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
 
         vm.stopPrank();
     }
@@ -313,7 +313,7 @@ contract ZoraCreatorMerkleMinterStrategyTest is Test {
 
         vm.startPrank(mintTo);
         vm.expectRevert(abi.encodeWithSignature("WrongValueSent()"));
-        target.purchase{value: ethToSend}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
+        target.mint{value: ethToSend}(merkleMinter, newTokenId, 10, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
     }
 
     function test_ResetSale() external {

--- a/test/nft/ZoraCreator1155.t.sol
+++ b/test/nft/ZoraCreator1155.t.sol
@@ -382,7 +382,7 @@ contract ZoraCreator1155Test is Test {
         target.adminMintBatch(address(0), tokenIds, quantities, "");
     }
 
-    function test_purchase(uint256 quantity) external {
+    function test_mint(uint256 quantity) external {
         init();
 
         vm.prank(admin);
@@ -393,24 +393,24 @@ contract ZoraCreator1155Test is Test {
         target.addPermission(tokenId, address(minter), adminRole);
 
         vm.prank(admin);
-        target.purchase(minter, tokenId, quantity, abi.encode(recipient));
+        target.mint(minter, tokenId, quantity, abi.encode(recipient));
 
         (, , uint256 totalMinted) = target.tokens(tokenId);
         assertEq(totalMinted, quantity);
         assertEq(target.balanceOf(recipient, tokenId), quantity);
     }
 
-    function test_purchase_revertOnlyMinter() external {
+    function test_mint_revertOnlyMinter() external {
         init();
 
         vm.prank(admin);
         uint256 tokenId = target.setupNewToken("test", 1000);
 
         vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.UserMissingRoleForToken.selector, address(0), tokenId, target.PERMISSION_BIT_MINTER()));
-        target.purchase(SimpleMinter(payable(address(0))), tokenId, 0, "");
+        target.mint(SimpleMinter(payable(address(0))), tokenId, 0, "");
     }
 
-    function test_purchase_revertCannotMintMoreTokens() external {
+    function test_mint_revertCannotMintMoreTokens() external {
         init();
 
         vm.prank(admin);
@@ -422,7 +422,7 @@ contract ZoraCreator1155Test is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.CannotMintMoreTokens.selector, tokenId));
         vm.prank(admin);
-        target.purchase(minter, tokenId, 1001, abi.encode(recipient));
+        target.mint(minter, tokenId, 1001, abi.encode(recipient));
     }
 
     function test_callSale() external {
@@ -483,7 +483,7 @@ contract ZoraCreator1155Test is Test {
         target.addPermission(tokenId, address(minter), adminRole);
 
         vm.prank(admin);
-        target.purchase(minter, tokenId, 5, abi.encode(recipient));
+        target.mint(minter, tokenId, 5, abi.encode(recipient));
 
         vm.prank(recipient);
         target.burn(tokenId, 3);
@@ -501,7 +501,7 @@ contract ZoraCreator1155Test is Test {
 
         vm.deal(admin, 1 ether);
         vm.prank(admin);
-        target.purchase{value: 1 ether}(minter, tokenId, 1000, abi.encode(recipient));
+        target.mint{value: 1 ether}(minter, tokenId, 1000, abi.encode(recipient));
 
         vm.prank(admin);
         target.withdrawAll();
@@ -509,7 +509,7 @@ contract ZoraCreator1155Test is Test {
         assertEq(admin.balance, 1 ether);
     }
 
-    function test_withdrawAll_revertETHWtihdrawFailed(uint256 purchaseAmount, uint256 withdrawAmount) external {
+    function test_withdrawAll_revertETHWithdrawFailed(uint256 purchaseAmount, uint256 withdrawAmount) external {
         vm.assume(withdrawAmount <= purchaseAmount);
         init();
 
@@ -527,7 +527,7 @@ contract ZoraCreator1155Test is Test {
 
         vm.deal(admin, 1 ether);
         vm.prank(admin);
-        target.purchase{value: 1 ether}(minter, tokenId, 1000, abi.encode(recipient));
+        target.mint{value: 1 ether}(minter, tokenId, 1000, abi.encode(recipient));
 
         vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.ETHWithdrawFailed.selector, minter, 1 ether));
         vm.prank(address(minter));
@@ -547,7 +547,7 @@ contract ZoraCreator1155Test is Test {
 
         vm.deal(admin, purchaseAmount);
         vm.prank(admin);
-        target.purchase{value: purchaseAmount}(minter, tokenId, 1000, abi.encode(recipient));
+        target.mint{value: purchaseAmount}(minter, tokenId, 1000, abi.encode(recipient));
 
         console.log("recipient balance before ", recipient.balance);
         vm.prank(admin);
@@ -572,7 +572,7 @@ contract ZoraCreator1155Test is Test {
 
         vm.deal(admin, purchaseAmount);
         vm.prank(admin);
-        target.purchase{value: purchaseAmount}(minter, tokenId, 1000, abi.encode(recipient));
+        target.mint{value: purchaseAmount}(minter, tokenId, 1000, abi.encode(recipient));
 
         vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.FundsWithdrawInsolvent.selector, withdrawAmount, purchaseAmount));
         vm.prank(admin);
@@ -593,7 +593,7 @@ contract ZoraCreator1155Test is Test {
 
         vm.deal(admin, 1 ether);
         vm.prank(admin);
-        target.purchase{value: 1 ether}(minter, tokenId, 1000, abi.encode(recipient));
+        target.mint{value: 1 ether}(minter, tokenId, 1000, abi.encode(recipient));
 
         vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.ETHWithdrawFailed.selector, minter, 1 ether));
         vm.prank(admin);


### PR DESCRIPTION
More consistent and better UX for free mints.

Can be used to align with `IMinter` interface.