### PR TITLE
1155 - include abis in published package

### DIFF
--- a/.changeset/odd-poems-lie.md
+++ b/.changeset/odd-poems-lie.md
@@ -1,0 +1,5 @@
+---
+"@zoralabs/zora-1155-contracts": patch
+---
+
+Exporting abi

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Compiler files
 cache/
 out/
+!artifacts/.gitinclude
+artifacts/
 
 # Ignores development broadcast logs
 # !/broadcast

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Compiler files
 cache/
 out/
-!abis/.gitinclude
 abis/
 
 # Ignores development broadcast logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Compiler files
 cache/
 out/
-!artifacts/.gitinclude
-artifacts/
+!abis/.gitinclude
+abis/
 
 # Ignores development broadcast logs
 # !/broadcast

--- a/packages/1155-contracts/foundry.toml
+++ b/packages/1155-contracts/foundry.toml
@@ -5,6 +5,7 @@ allow_paths = ["node_modules/@zoralabs/protocol-rewards"]
 optimizer = true
 optimizer_runs = 50
 out = 'out'
+extra_output_files = ['abi']
 solc_version = '0.8.17'
 src = 'src'
 via_ir = true

--- a/packages/1155-contracts/foundry.toml
+++ b/packages/1155-contracts/foundry.toml
@@ -5,7 +5,6 @@ allow_paths = ["node_modules/@zoralabs/protocol-rewards"]
 optimizer = true
 optimizer_runs = 50
 out = 'out'
-extra_output_files = ['abi']
 solc_version = '0.8.17'
 src = 'src'
 via_ir = true

--- a/packages/1155-contracts/package.json
+++ b/packages/1155-contracts/package.json
@@ -17,7 +17,8 @@
     "lint": "yarn run prettier:check",
     "coverage": "forge coverage --report lcov",
     "write-gas-report": "forge test --gas-report > gasreport.ansi",
-    "prepack": "yarn wagmi && cp out/**/*.abi.json artifacts/ && yarn bundle-configs && yarn build",
+    "copy-abis": "tsx script/bundle-abis.ts",
+    "prepack": "yarn wagmi && yarn copy-abis && yarn bundle-configs && yarn build",
     "update-new-deployment-addresses": "node script/copy-deployed-contracts.mjs deploy",
     "update-contract-version": "node script/update-contract-version.mjs",
     "build:contracts": "forge build",
@@ -37,6 +38,7 @@
     "addresses/",
     "chainConfigs/",
     "package/",
+    "abis/",
     "_imagine/"
   ],
   "dependencies": {

--- a/packages/1155-contracts/package.json
+++ b/packages/1155-contracts/package.json
@@ -17,7 +17,7 @@
     "lint": "yarn run prettier:check",
     "coverage": "forge coverage --report lcov",
     "write-gas-report": "forge test --gas-report > gasreport.ansi",
-    "prepack": "yarn wagmi && yarn bundle-configs && yarn build",
+    "prepack": "yarn wagmi && cp out/**/*.abi.json artifacts/ && yarn bundle-configs && yarn build",
     "update-new-deployment-addresses": "node script/copy-deployed-contracts.mjs deploy",
     "update-contract-version": "node script/update-contract-version.mjs",
     "build:contracts": "forge build",

--- a/packages/1155-contracts/script/bundle-abis.ts
+++ b/packages/1155-contracts/script/bundle-abis.ts
@@ -1,0 +1,109 @@
+import { promises as fs } from "fs";
+import { basename, extname, join, resolve } from "pathe";
+import { glob } from "glob";
+import { ContractConfig } from "@wagmi/cli";
+
+const defaultExcludes = [
+  "Common.sol/**",
+  "Components.sol/**",
+  "Script.sol/**",
+  "StdAssertions.sol/**",
+  "StdInvariant.sol/**",
+  "StdError.sol/**",
+  "StdCheats.sol/**",
+  "StdMath.sol/**",
+  "StdJson.sol/**",
+  "StdStorage.sol/**",
+  "StdUtils.sol/**",
+  "Vm.sol/**",
+  "console.sol/**",
+  "console2.sol/**",
+  "test.sol/**",
+  "**.s.sol/*.json",
+  "**.t.sol/*.json",
+];
+
+// design inspired by https://github.com/wagmi-dev/wagmi/blob/main/packages/cli/src/plugins/foundry.ts
+
+export const readContracts = async ({
+  deployments = {} as any,
+  exclude = defaultExcludes,
+  include = ["*.json"],
+  namePrefix = "",
+  project_ = "./",
+}) => {
+  // get all the files in ./out
+  function getContractName(artifactPath: string, usePrefix = true) {
+    const filename = basename(artifactPath);
+    const extension = extname(artifactPath);
+    return `${usePrefix ? namePrefix : ""}${filename.replace(extension, "")}`;
+  }
+
+  async function getContract(artifactPath: string) {
+    const artifact = JSON.parse(await fs.readFile(artifactPath, "utf-8"));
+    return {
+      abi: artifact.abi,
+      address: (deployments as Record<string, ContractConfig["address"]>)[
+        getContractName(artifactPath, false)
+      ],
+      name: getContractName(artifactPath),
+    };
+  }
+
+  async function getArtifactPaths(artifactsDirectory: string) {
+    return await glob([
+      ...include.map((x) => `${artifactsDirectory}/**/${x}`),
+      ...exclude.map((x) => `!${artifactsDirectory}/**/${x}`),
+    ]);
+  }
+
+  const project = resolve(process.cwd(), project_ ?? "");
+
+  const config = {
+    out: "out",
+    src: "src",
+  };
+
+  const artifactsDirectory = join(project, config.out);
+
+  const artifactPaths = await getArtifactPaths(artifactsDirectory);
+  const contracts = [];
+  for (const artifactPath of artifactPaths) {
+    const contract = await getContract(artifactPath);
+    if (!contract.abi?.length) continue;
+    contracts.push(contract);
+  }
+  return contracts;
+};
+
+async function saveContractsAbisJson(contracts: { abi: any; name: string }[]) {
+  // for each contract, write abi to ./abis/{contractName}.json
+
+  const abisFolder = "./abis";
+
+  // mkdir - p ./abis:
+  await fs.mkdir(abisFolder, { recursive: true });
+  // remove abis folder:
+  await fs.rm(abisFolder, { recursive: true });
+  // add it back
+  // mkdir - p ./abis:
+  await fs.mkdir(abisFolder, { recursive: true });
+
+  // now write abis:
+  await Promise.all(
+    contracts.map(async (contract) => {
+      const abiJson = JSON.stringify(contract.abi, null, 2);
+      const abiJsonPath = `${abisFolder}/${contract.name}.json`;
+
+      await fs.writeFile(abiJsonPath, abiJson);
+    })
+  );
+}
+
+async function main() {
+  const contracts = await readContracts({});
+
+  await saveContractsAbisJson(contracts);
+}
+
+main();

--- a/packages/1155-contracts/wagmi.config.ts
+++ b/packages/1155-contracts/wagmi.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "@wagmi/cli";
 import { foundry } from "@wagmi/cli/plugins";
 import { readdirSync, readFileSync } from "fs";
+import { publishAbisJson } from "./publishAbisPlugin";
 
 type ContractNames =
   | "ZoraCreator1155FactoryImpl"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4262,6 +4262,7 @@ why-is-node-running@^2.2.2:
     stackback "0.0.2"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
* When publishing package, include the abis in the published package, by running a script that grabs them from foundry and copies them to the `./abis` folder