### PR TITLE
Premint V2

### DIFF
--- a/.changeset/violet-starfishes-visit.md
+++ b/.changeset/violet-starfishes-visit.md
@@ -1,0 +1,114 @@
+---
+"@zoralabs/zora-1155-contracts": minor
+---
+
+# Premint v2
+
+### New fields on signature
+
+Adding a new `PremintConfigV2` struct that can be signed, that now contains a `createReferral`.  `ZoraCreator1155PremintExecutor` recognizes new version of the `PremintConfig`, and still works with the v1 (legacy) version of the `PremintConfig`.  
+
+Additional changes to the `PremintConfigV2`:
+* `tokenConfig.royaltyMintSchedule` has been removed as it is deprecated and no longer recognized by new versions of the 1155 contract
+* `tokenConfig.royaltyRecipient` has been renamed to `tokenConfig.payoutRecipient` to better reflect the fact that this address is used to receive creator rewards, secondary royalties, and paid mint funds.  This is the address that will be set on the `royaltyRecipient` for the created token on the 1155 contract, which is the address that receives creator rewards and secondary royalties for the token, and on the `fundsRecipient` on the ZoraCreatorFixedPriceSaleStrategy contract for the token, which is the address that receives paid mint funds for the token.
+
+### New MintArguments on premint functions, specifying `mintRecipient` and `mintReferral`
+
+`mintReferral` and `mintRecipient` are now specified in the premint functions on the `ZoraCreator1155PremintExecutor`, via the `MintArguments mintArguments` param; new `premintV1` and `premintV2` function now take the `MintArguments` struct as an argument which contains `mintRecipient`, defining  which account will receive the minted tokens, `mintComment`, and `mintReferral`, defining which account will receive a mintReferral reward, if any.  `mintRecipient` must be specified or else it reverts.
+
+### New signature validation methods
+
+ZoraCreator1155PremintExecutor can now validate signatures by passing it the contract address, instead of needing to pass the full contract creation config, enabling it to validate signatures for 1155 contracts that were not created via the premint executor contract.  This allows premints signatures to be validated on contracts that have been upgraded to a version that supports premints, and allows premints to be created on contracts that were not created via the premint executor contract. These functions are called `isValidSignatureV1` and `isValidSignatureV2` for v1 and v2 of the premint config structs and signatures correspondingly.
+
+### Changes to handling of setting of fundsRecipient
+
+Previously the `fundsRecipient` on the fixeed priced minters sales config for the token was set to the signer of the premint.  This has been changed to be set to the `payoutRecipient` of the premint config for v2 of premint config, and to the `royaltyRecipient` of the premint config for v1 of the premint config, for 1155 contracts that are to be newly created, and for existing 1155 contracts that are upgraded to the latest version and execute a v1 of the premint config.
+
+### Changes to 1155's `delegateSetupNewToken`
+
+`delegateSetupNewToken` on 1155 contract has been updated to now take an abi encoded premint config, premint config version, and send it to an external library to decode the config, the signer, and setup actions.  Previously it took a non-encoded PremintConfig.  This new change allows this function signature to support multiple versions of a premint config, while offloading decoding of the config and the corresponding setup actions to the external library.  This ultimately allows supporting multiple versions of a premint config and corresponding signature without increasing codespace. 
+
+`PremintConfigV2` are updated to containe `createReferral`, and now look like:
+```solidity
+struct PremintConfigV2 {
+    // The config for the token to be created
+    TokenCreationConfigV2 tokenConfig;
+    // Unique id of the token, used to ensure that multiple signatures can't be used to create the same intended token.
+    // only one signature per token id, scoped to the contract hash can be executed.
+    uint32 uid;
+    // Version of this premint, scoped to the uid and contract.  Not used for logic in the contract, but used externally to track the newest version
+    uint32 version;
+    // If executing this signature results in preventing any signature with this uid from being minted.
+    bool deleted;
+}
+
+struct TokenCreationConfigV2 {
+    // Metadata URI for the created token
+    string tokenURI;
+    // Max supply of the created token
+    uint256 maxSupply;
+    // Max tokens that can be minted for an address, 0 if unlimited
+    uint64 maxTokensPerAddress;
+    // Price per token in eth wei. 0 for a free mint.
+    uint96 pricePerToken;
+    // The start time of the mint, 0 for immediate.  Prevents signatures from being used until the start time.
+    uint64 mintStart;
+    // The duration of the mint, starting from the first mint of this token. 0 for infinite
+    uint64 mintDuration;
+    // RoyaltyBPS for created tokens. The royalty amount in basis points for secondary sales.
+    uint32 royaltyBPS;
+    // The address that will receive creatorRewards, secondary royalties, and paid mint funds.  This is the address that will be set on the `royaltyRecipient` for the created token on the 1155 contract, which is the address that receives creator rewards and secondary royalties for the token, and on the `fundsRecipient` on the ZoraCreatorFixedPriceSaleStrategy contract for the token, which is the address that receives paid mint funds for the token.
+    address payoutRecipient;
+    // Fixed price minter address
+    address fixedPriceMinter;
+    // create referral
+    address createReferral;
+}
+```
+`PremintConfig` fields are **the same as they were before, but are treated as a version 1**:
+
+```solidity
+struct PremintConfig {
+    // The config for the token to be created
+    TokenCreationConfig tokenConfig;
+    // Unique id of the token, used to ensure that multiple signatures can't be used to create the same intended token.
+    // only one signature per token id, scoped to the contract hash can be executed.
+    uint32 uid;
+    // Version of this premint, scoped to the uid and contract.  Not used for logic in the contract, but used externally to track the newest version
+    uint32 version;
+    // If executing this signature results in preventing any signature with this uid from being minted.
+    bool deleted;
+}
+
+struct TokenCreationConfig {
+    // Metadata URI for the created token
+    string tokenURI;
+    // Max supply of the created token
+    uint256 maxSupply;
+    // Max tokens that can be minted for an address, 0 if unlimited
+    uint64 maxTokensPerAddress;
+    // Price per token in eth wei. 0 for a free mint.
+    uint96 pricePerToken;
+    // The start time of the mint, 0 for immediate.  Prevents signatures from being used until the start time.
+    uint64 mintStart;
+    // The duration of the mint, starting from the first mint of this token. 0 for infinite
+    uint64 mintDuration;
+    // deperecated field; will be ignored.
+    uint32 royaltyMintSchedule;
+    // RoyaltyBPS for created tokens. The royalty amount in basis points for secondary sales.
+    uint32 royaltyBPS;
+    // The address that will receive creatorRewards, secondary royalties, and paid mint funds.  This is the address that will be set on the `royaltyRecipient` for the created token on the 1155 contract, which is the address that receives creator rewards and secondary royalties for the token, and on the `fundsRecipient` on the ZoraCreatorFixedPriceSaleStrategy contract for the token, which is the address that receives paid mint funds for the token.
+    address royaltyRecipient;
+    // Fixed price minter address
+    address fixedPriceMinter;
+}
+```
+
+### changes to `ZoraCreator1155PremintExecutorImpl`:
+
+* new function `premintV1` - takes a `PremintConfig`, and premint v1 signature, and executes a premint, with added functionality of being able to specify mint referral and mint recipient
+* new function `premintV2` - takes a `PremintConfigV2` signature and executes a premint, with being able to specify mint referral and mint recipient
+* deprecated function `premint` - call `premintV1` instead
+* new function `isValidSignatureV1` - takes an 1155 address, contract admin, premint v1 config and signature,  and validates the signature.  Can be used for 1155 contracts that were not created via the premint executor contract.
+* new function `isValidSignatureV2` - takes an 1155 address, contract admin, premint v2 config and signature,  and validates the signature.  Can be used for 1155 contracts that were not created via the premint executor contract.
+* deprecated function `isValidSignature` - call `isValidSignatureV1` instead

--- a/packages/1155-contracts/src/delegation/ZoraCreator1155Attribution.sol
+++ b/packages/1155-contracts/src/delegation/ZoraCreator1155Attribution.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.17;
 
 import {IMinter1155} from "../interfaces/IMinter1155.sol";
 import {IZoraCreator1155} from "../interfaces/IZoraCreator1155.sol";
+import {IZoraCreator1155Errors} from "../interfaces/IZoraCreator1155Errors.sol";
 import {ICreatorRoyaltiesControl} from "../interfaces/ICreatorRoyaltiesControl.sol";
 import {ECDSAUpgradeable} from "@zoralabs/openzeppelin-contracts-upgradeable/contracts/utils/cryptography/ECDSAUpgradeable.sol";
 import {ZoraCreatorFixedPriceSaleStrategy} from "../minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.sol";
@@ -14,6 +15,18 @@ struct ContractCreationConfig {
     string contractURI;
     // Name of the created contract
     string contractName;
+}
+
+struct PremintConfig {
+    // The config for the token to be created
+    TokenCreationConfig tokenConfig;
+    // Unique id of the token, used to ensure that multiple signatures can't be used to create the same intended token.
+    // only one signature per token id, scoped to the contract hash can be executed.
+    uint32 uid;
+    // Version of this premint, scoped to the uid and contract.  Not used for logic in the contract, but used externally to track the newest version
+    uint32 version;
+    // If executing this signature results in preventing any signature with this uid from being minted.
+    bool deleted;
 }
 
 struct TokenCreationConfig {
@@ -29,19 +42,22 @@ struct TokenCreationConfig {
     uint64 mintStart;
     // The duration of the mint, starting from the first mint of this token. 0 for infinite
     uint64 mintDuration;
-    // RoyaltyMintSchedule for created tokens. Every nth token will go to the royalty recipient.
+    // deperecated field; will be ignored.
     uint32 royaltyMintSchedule;
     // RoyaltyBPS for created tokens. The royalty amount in basis points for secondary sales.
     uint32 royaltyBPS;
-    // RoyaltyRecipient for created tokens. The address that will receive the royalty payments.
+    // This is the address that will be set on the `royaltyRecipient` for the created token on the 1155 contract,
+    // which is the address that receives creator rewards and secondary royalties for the token,
+    // and on the `fundsRecipient` on the ZoraCreatorFixedPriceSaleStrategy contract for the token,
+    // which is the address that receives paid mint funds for the token.
     address royaltyRecipient;
     // Fixed price minter address
     address fixedPriceMinter;
 }
 
-struct PremintConfig {
+struct PremintConfigV2 {
     // The config for the token to be created
-    TokenCreationConfig tokenConfig;
+    TokenCreationConfigV2 tokenConfig;
     // Unique id of the token, used to ensure that multiple signatures can't be used to create the same intended token.
     // only one signature per token id, scoped to the contract hash can be executed.
     uint32 uid;
@@ -51,94 +67,124 @@ struct PremintConfig {
     bool deleted;
 }
 
-/// @title Library for enables a creator to signal intent to create a Zora erc1155 contract or new token on that
-/// contract by signing a transaction but not paying gas, and have a third party/collector pay the gas
-/// by executing the transaction.  Functions are exposed as external to allow contracts to import this lib and not increase their
-/// size.
-/// @author @oveddan
+struct TokenCreationConfigV2 {
+    // Metadata URI for the created token
+    string tokenURI;
+    // Max supply of the created token
+    uint256 maxSupply;
+    // Max tokens that can be minted for an address, 0 if unlimited
+    uint64 maxTokensPerAddress;
+    // Price per token in eth wei. 0 for a free mint.
+    uint96 pricePerToken;
+    // The start time of the mint, 0 for immediate.  Prevents signatures from being used until the start time.
+    uint64 mintStart;
+    // The duration of the mint, starting from the first mint of this token. 0 for infinite
+    uint64 mintDuration;
+    // RoyaltyBPS for created tokens. The royalty amount in basis points for secondary sales.
+    uint32 royaltyBPS;
+    // This is the address that will be set on the `royaltyRecipient` for the created token on the 1155 contract,
+    // which is the address that receives creator rewards and secondary royalties for the token,
+    // and on the `fundsRecipient` on the ZoraCreatorFixedPriceSaleStrategy contract for the token,
+    // which is the address that receives paid mint funds for the token.
+    address payoutRecipient;
+    // Fixed price minter address
+    address fixedPriceMinter;
+    // create referral
+    address createReferral;
+}
+
 library ZoraCreator1155Attribution {
-    /* start eip712 functionality */
     string internal constant NAME = "Preminter";
-    string internal constant VERSION = "1";
     bytes32 internal constant HASHED_NAME = keccak256(bytes(NAME));
-    bytes32 internal constant HASHED_VERSION = keccak256(bytes(VERSION));
-    bytes32 internal constant TYPE_HASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    string internal constant VERSION_1 = "1";
+    bytes32 internal constant HASHED_VERSION_1 = keccak256(bytes(VERSION_1));
+    string internal constant VERSION_2 = "2";
+    bytes32 internal constant HASHED_VERSION_2 = keccak256(bytes(VERSION_2));
 
     /**
      * @dev Returns the domain separator for the specified chain.
      */
-    function _domainSeparatorV4(uint256 chainId, address verifyingContract) internal pure returns (bytes32) {
-        return _buildDomainSeparator(HASHED_NAME, HASHED_VERSION, verifyingContract, chainId);
+    function _domainSeparatorV4(uint256 chainId, address verifyingContract, bytes32 hashedName, bytes32 hashedVersion) private pure returns (bytes32) {
+        return _buildDomainSeparator(hashedName, hashedVersion, verifyingContract, chainId);
     }
 
     function _buildDomainSeparator(bytes32 nameHash, bytes32 versionHash, address verifyingContract, uint256 chainId) private pure returns (bytes32) {
         return keccak256(abi.encode(TYPE_HASH, nameHash, versionHash, chainId, verifyingContract));
     }
 
-    function _hashTypedDataV4(bytes32 structHash, address verifyingContract, uint256 chainId) private pure returns (bytes32) {
-        return ECDSAUpgradeable.toTypedDataHash(_domainSeparatorV4(chainId, verifyingContract), structHash);
-    }
-
-    /* end eip712 functionality */
-
-    function recoverSigner(
-        PremintConfig calldata premintConfig,
-        bytes calldata signature,
-        address erc1155Contract,
+    function _hashTypedDataV4(
+        bytes32 structHash,
+        bytes32 hashedName,
+        bytes32 hashedVersion,
+        address verifyingContract,
         uint256 chainId
-    ) internal pure returns (address signatory) {
-        // first validate the signature - the creator must match the signer of the message
-        return recoverSignerHashed(hashPremint(premintConfig), signature, erc1155Contract, chainId);
+    ) private pure returns (bytes32) {
+        return ECDSAUpgradeable.toTypedDataHash(_domainSeparatorV4(chainId, verifyingContract, hashedName, hashedVersion), structHash);
     }
 
     function recoverSignerHashed(
         bytes32 hashedPremintConfig,
         bytes calldata signature,
         address erc1155Contract,
+        bytes32 signatureVersion,
         uint256 chainId
-    ) public pure returns (address signatory) {
+    ) internal pure returns (address signatory) {
         // first validate the signature - the creator must match the signer of the message
-        bytes32 digest = _hashTypedDataV4(
+        bytes32 digest = premintHashedTypeDataV4(
             hashedPremintConfig,
             // here we pass the current contract and chain id, ensuring that the message
             // only works for the current chain and contract id
             erc1155Contract,
+            signatureVersion,
             chainId
         );
 
-        signatory = ECDSAUpgradeable.recover(digest, signature);
+        (signatory, ) = ECDSAUpgradeable.tryRecover(digest, signature);
     }
 
-    /// Gets hash data to sign for a premint.  Allows specifying a different chain id and contract address so that the signature
-    /// can be verified on a different chain.
+    /// Gets hash data to sign for a premint.
     /// @param erc1155Contract Contract address that signature is to be verified against
     /// @param chainId Chain id that signature is to be verified on
-    function premintHashedTypeDataV4(PremintConfig calldata premintConfig, address erc1155Contract, uint256 chainId) external pure returns (bytes32) {
+    function premintHashedTypeDataV4(bytes32 structHash, address erc1155Contract, bytes32 signatureVersion, uint256 chainId) internal pure returns (bytes32) {
         // build the struct hash to be signed
         // here we pass the chain id, allowing the message to be signed for another chain
-        return _hashTypedDataV4(hashPremint(premintConfig), erc1155Contract, chainId);
+        return _hashTypedDataV4(structHash, HASHED_NAME, signatureVersion, erc1155Contract, chainId);
     }
 
-    bytes32 constant ATTRIBUTION_DOMAIN =
+    bytes32 constant ATTRIBUTION_DOMAIN_V1 =
         keccak256(
             "CreatorAttribution(TokenCreationConfig tokenConfig,uint32 uid,uint32 version,bool deleted)TokenCreationConfig(string tokenURI,uint256 maxSupply,uint64 maxTokensPerAddress,uint96 pricePerToken,uint64 mintStart,uint64 mintDuration,uint32 royaltyMintSchedule,uint32 royaltyBPS,address royaltyRecipient,address fixedPriceMinter)"
         );
 
-    function hashPremint(PremintConfig calldata premintConfig) public pure returns (bytes32) {
+    function hashPremint(PremintConfig memory premintConfig) internal pure returns (bytes32) {
         return
-            keccak256(abi.encode(ATTRIBUTION_DOMAIN, _hashToken(premintConfig.tokenConfig), premintConfig.uid, premintConfig.version, premintConfig.deleted));
+            keccak256(
+                abi.encode(ATTRIBUTION_DOMAIN_V1, _hashToken(premintConfig.tokenConfig), premintConfig.uid, premintConfig.version, premintConfig.deleted)
+            );
     }
 
-    bytes32 constant TOKEN_DOMAIN =
+    bytes32 constant ATTRIBUTION_DOMAIN_V2 =
+        keccak256(
+            "CreatorAttribution(TokenCreationConfig tokenConfig,uint32 uid,uint32 version,bool deleted)TokenCreationConfig(string tokenURI,uint256 maxSupply,uint64 maxTokensPerAddress,uint96 pricePerToken,uint64 mintStart,uint64 mintDuration,uint32 royaltyBPS,address royaltyRecipient,address fixedPriceMinter,address createReferral)"
+        );
+
+    function hashPremint(PremintConfigV2 memory premintConfig) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(ATTRIBUTION_DOMAIN_V2, _hashToken(premintConfig.tokenConfig), premintConfig.uid, premintConfig.version, premintConfig.deleted)
+            );
+    }
+
+    bytes32 constant TOKEN_DOMAIN_V1 =
         keccak256(
             "TokenCreationConfig(string tokenURI,uint256 maxSupply,uint64 maxTokensPerAddress,uint96 pricePerToken,uint64 mintStart,uint64 mintDuration,uint32 royaltyMintSchedule,uint32 royaltyBPS,address royaltyRecipient,address fixedPriceMinter)"
         );
 
-    function _hashToken(TokenCreationConfig calldata tokenConfig) private pure returns (bytes32) {
+    function _hashToken(TokenCreationConfig memory tokenConfig) private pure returns (bytes32) {
         return
             keccak256(
                 abi.encode(
-                    TOKEN_DOMAIN,
+                    TOKEN_DOMAIN_V1,
                     _stringHash(tokenConfig.tokenURI),
                     tokenConfig.maxSupply,
                     tokenConfig.maxTokensPerAddress,
@@ -153,8 +199,61 @@ library ZoraCreator1155Attribution {
             );
     }
 
-    function _stringHash(string calldata value) private pure returns (bytes32) {
+    bytes32 constant TOKEN_DOMAIN_V2 =
+        keccak256(
+            "TokenCreationConfig(string tokenURI,uint256 maxSupply,uint64 maxTokensPerAddress,uint96 pricePerToken,uint64 mintStart,uint64 mintDuration,uint32 royaltyBPS,address payoutRecipient,address fixedPriceMinter,address createReferral)"
+        );
+
+    function _hashToken(TokenCreationConfigV2 memory tokenConfig) private pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    TOKEN_DOMAIN_V1,
+                    _stringHash(tokenConfig.tokenURI),
+                    tokenConfig.maxSupply,
+                    tokenConfig.maxTokensPerAddress,
+                    tokenConfig.pricePerToken,
+                    tokenConfig.mintStart,
+                    tokenConfig.mintDuration,
+                    tokenConfig.royaltyBPS,
+                    tokenConfig.payoutRecipient,
+                    tokenConfig.fixedPriceMinter,
+                    tokenConfig.createReferral
+                )
+            );
+    }
+
+    bytes32 internal constant TYPE_HASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+
+    function _stringHash(string memory value) private pure returns (bytes32) {
         return keccak256(bytes(value));
+    }
+
+    /// @notice copied from SharedBaseConstants
+    uint256 constant CONTRACT_BASE_ID = 0;
+    /// @dev copied from ZoraCreator1155Impl
+    uint256 constant PERMISSION_BIT_MINTER = 2 ** 2;
+
+    function isValidSignature(
+        address originalPremintCreator,
+        address contractAddress,
+        bytes32 structHash,
+        bytes32 hashedVersion,
+        bytes calldata signature
+    ) internal view returns (bool isValid, address recoveredSigner) {
+        recoveredSigner = recoverSignerHashed(structHash, signature, contractAddress, hashedVersion, block.chainid);
+
+        if (recoveredSigner == address(0)) {
+            return (false, address(0));
+        }
+
+        // if contract hasn't been created, signer must be the contract admin on the config
+        if (contractAddress.code.length == 0) {
+            isValid = recoveredSigner == originalPremintCreator;
+        } else {
+            // if contract has been created, signer must have mint new token permission
+            isValid = IZoraCreator1155(contractAddress).isAdminOrRole(recoveredSigner, CONTRACT_BASE_ID, PERMISSION_BIT_MINTER);
+        }
     }
 }
 
@@ -163,14 +262,45 @@ library ZoraCreator1155Attribution {
 library PremintTokenSetup {
     uint256 constant PERMISSION_BIT_MINTER = 2 ** 2;
 
-    function makeSetupNewTokenCalls(
+    /// @notice Build token setup actions for a v2 preminted token
+    function makeSetupNewTokenCalls(uint256 newTokenId, TokenCreationConfigV2 memory tokenConfig) internal view returns (bytes[] memory calls) {
+        return
+            _buildCalls({
+                newTokenId: newTokenId,
+                fixedPriceMinterAddress: tokenConfig.fixedPriceMinter,
+                pricePerToken: tokenConfig.pricePerToken,
+                maxTokensPerAddress: tokenConfig.maxTokensPerAddress,
+                mintDuration: tokenConfig.mintDuration,
+                royaltyBPS: tokenConfig.royaltyBPS,
+                payoutRecipient: tokenConfig.payoutRecipient
+            });
+    }
+
+    /// @notice Build token setup actions for a v1 preminted token
+    function makeSetupNewTokenCalls(uint256 newTokenId, TokenCreationConfig memory tokenConfig) internal view returns (bytes[] memory calls) {
+        return
+            _buildCalls({
+                newTokenId: newTokenId,
+                fixedPriceMinterAddress: tokenConfig.fixedPriceMinter,
+                pricePerToken: tokenConfig.pricePerToken,
+                maxTokensPerAddress: tokenConfig.maxTokensPerAddress,
+                mintDuration: tokenConfig.mintDuration,
+                royaltyBPS: tokenConfig.royaltyBPS,
+                payoutRecipient: tokenConfig.royaltyRecipient
+            });
+    }
+
+    function _buildCalls(
         uint256 newTokenId,
-        address contractAdmin,
-        TokenCreationConfig calldata tokenConfig
-    ) external view returns (bytes[] memory calls) {
+        address fixedPriceMinterAddress,
+        uint96 pricePerToken,
+        uint64 maxTokensPerAddress,
+        uint64 mintDuration,
+        uint32 royaltyBPS,
+        address payoutRecipient
+    ) private view returns (bytes[] memory calls) {
         calls = new bytes[](3);
 
-        address fixedPriceMinterAddress = tokenConfig.fixedPriceMinter;
         // build array of the calls to make
         // get setup actions and invoke them
         // set up the sales strategy
@@ -186,7 +316,7 @@ library PremintTokenSetup {
             abi.encodeWithSelector(
                 ZoraCreatorFixedPriceSaleStrategy.setSale.selector,
                 newTokenId,
-                _buildNewSalesConfig(contractAdmin, tokenConfig.pricePerToken, tokenConfig.maxTokensPerAddress, tokenConfig.mintDuration)
+                _buildNewSalesConfig(pricePerToken, maxTokensPerAddress, mintDuration)
             )
         );
 
@@ -194,16 +324,11 @@ library PremintTokenSetup {
         calls[2] = abi.encodeWithSelector(
             IZoraCreator1155.updateRoyaltiesForToken.selector,
             newTokenId,
-            ICreatorRoyaltiesControl.RoyaltyConfiguration({
-                royaltyBPS: tokenConfig.royaltyBPS,
-                royaltyRecipient: tokenConfig.royaltyRecipient,
-                royaltyMintSchedule: tokenConfig.royaltyMintSchedule
-            })
+            ICreatorRoyaltiesControl.RoyaltyConfiguration({royaltyBPS: royaltyBPS, royaltyRecipient: payoutRecipient, royaltyMintSchedule: 0})
         );
     }
 
     function _buildNewSalesConfig(
-        address creator,
         uint96 pricePerToken,
         uint64 maxTokensPerAddress,
         uint64 duration
@@ -217,7 +342,134 @@ library PremintTokenSetup {
                 saleStart: saleStart,
                 saleEnd: saleEnd,
                 maxTokensPerAddress: maxTokensPerAddress,
-                fundsRecipient: creator
+                fundsRecipient: address(0)
             });
+    }
+}
+
+library PremintEncoding {
+    function encodePremintV1(PremintConfig memory premintConfig) internal pure returns (bytes memory encodedPremintConfig, bytes32 hashedVersion) {
+        return (abi.encode(premintConfig), ZoraCreator1155Attribution.HASHED_VERSION_1);
+    }
+
+    function encodePremintV2(PremintConfigV2 memory premintConfig) internal pure returns (bytes memory encodedPremintConfig, bytes32 hashedVersion) {
+        return (abi.encode(premintConfig), ZoraCreator1155Attribution.HASHED_VERSION_2);
+    }
+}
+
+struct DecodedCreatorAttribution {
+    bytes32 structHash;
+    string domainName;
+    string version;
+    address creator;
+    bytes signature;
+}
+
+struct DelegatedTokenSetup {
+    DecodedCreatorAttribution attribution;
+    uint32 uid;
+    string tokenURI;
+    uint256 maxSupply;
+    address createReferral;
+}
+
+/// @notice Utility library to decode and recover delegated token setup data from a signature.
+/// Function called by the erc1155 contract is marked external to reduce contract size in calling contract.
+library DelegatedTokenCreation {
+    /// @notice Decode and recover delegated token setup data from a signature. Works with multiple versions of
+    /// a signature.  Takes an abi encoded premint config, version of the encoded premint config, and a signature,
+    /// decodes the config, and recoveres the signer of the config.  Based on the premint config, builds
+    /// setup actions for the token to be created.
+    /// @param premintConfigEncoded The abi encoded premint config
+    /// @param premintVersion The version of the premint config
+    /// @param signature The signature of the premint config
+    /// @param tokenContract The address of the token contract that the premint config is for
+    /// @param newTokenId The id of the token to be created
+    function decodeAndRecoverDelegatedTokenSetup(
+        bytes memory premintConfigEncoded,
+        bytes32 premintVersion,
+        bytes calldata signature,
+        address tokenContract,
+        uint256 newTokenId
+    ) external view returns (DelegatedTokenSetup memory params, DecodedCreatorAttribution memory creatorAttribution, bytes[] memory tokenSetupActions) {
+        // based on version of encoded premint config, decode corresponding premint config,
+        // and then recover signer from the signature, and then build token setup actions based
+        // on the decoded premint config.
+        if (premintVersion == ZoraCreator1155Attribution.HASHED_VERSION_1) {
+            PremintConfig memory premintConfig = abi.decode(premintConfigEncoded, (PremintConfig));
+
+            creatorAttribution = _recoverCreatorAttribution(
+                ZoraCreator1155Attribution.VERSION_1,
+                ZoraCreator1155Attribution.hashPremint(premintConfig),
+                tokenContract,
+                signature
+            );
+
+            (params, tokenSetupActions) = _recoverDelegatedTokenSetup(premintConfig, newTokenId);
+        } else {
+            PremintConfigV2 memory premintConfig = abi.decode(premintConfigEncoded, (PremintConfigV2));
+
+            creatorAttribution = _recoverCreatorAttribution(
+                ZoraCreator1155Attribution.VERSION_2,
+                ZoraCreator1155Attribution.hashPremint(premintConfig),
+                tokenContract,
+                signature
+            );
+
+            (params, tokenSetupActions) = _recoverDelegatedTokenSetup(premintConfig, newTokenId);
+        }
+    }
+
+    function _recoverCreatorAttribution(
+        string memory version,
+        bytes32 structHash,
+        address tokenContract,
+        bytes calldata signature
+    ) private view returns (DecodedCreatorAttribution memory attribution) {
+        attribution.version = version;
+
+        attribution.creator = ZoraCreator1155Attribution.recoverSignerHashed(structHash, signature, tokenContract, keccak256(bytes(version)), block.chainid);
+
+        attribution.signature = signature;
+        attribution.domainName = ZoraCreator1155Attribution.NAME;
+    }
+
+    function _recoverDelegatedTokenSetup(
+        PremintConfigV2 memory premintConfig,
+        uint256 nextTokenId
+    ) private view returns (DelegatedTokenSetup memory params, bytes[] memory tokenSetupActions) {
+        validatePremint(premintConfig.tokenConfig.mintStart, premintConfig.deleted);
+
+        params.uid = premintConfig.uid;
+
+        tokenSetupActions = PremintTokenSetup.makeSetupNewTokenCalls({newTokenId: nextTokenId, tokenConfig: premintConfig.tokenConfig});
+
+        params.tokenURI = premintConfig.tokenConfig.tokenURI;
+        params.maxSupply = premintConfig.tokenConfig.maxSupply;
+        params.createReferral = premintConfig.tokenConfig.createReferral;
+    }
+
+    function _recoverDelegatedTokenSetup(
+        PremintConfig memory premintConfig,
+        uint256 nextTokenId
+    ) private view returns (DelegatedTokenSetup memory params, bytes[] memory tokenSetupActions) {
+        validatePremint(premintConfig.tokenConfig.mintStart, premintConfig.deleted);
+
+        tokenSetupActions = PremintTokenSetup.makeSetupNewTokenCalls(nextTokenId, premintConfig.tokenConfig);
+
+        params.tokenURI = premintConfig.tokenConfig.tokenURI;
+        params.maxSupply = premintConfig.tokenConfig.maxSupply;
+    }
+
+    function validatePremint(uint64 mintStart, bool deleted) private view {
+        if (mintStart != 0 && mintStart > block.timestamp) {
+            // if the mint start is in the future, then revert
+            revert IZoraCreator1155Errors.MintNotYetStarted();
+        }
+        if (deleted) {
+            // if the signature says to be deleted, then dont execute any further minting logic;
+            // return 0
+            revert IZoraCreator1155Errors.PremintDeleted();
+        }
     }
 }

--- a/packages/1155-contracts/src/delegation/ZoraCreator1155PremintExecutorImplLib.sol
+++ b/packages/1155-contracts/src/delegation/ZoraCreator1155PremintExecutorImplLib.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {ContractCreationConfig} from "./ZoraCreator1155Attribution.sol";
+import {IZoraCreator1155} from "../interfaces/IZoraCreator1155.sol";
+import {IZoraCreator1155Factory} from "../interfaces/IZoraCreator1155Factory.sol";
+import {ICreatorRoyaltiesControl} from "../interfaces/ICreatorRoyaltiesControl.sol";
+import {IMinter1155} from "../interfaces/IMinter1155.sol";
+import {IZoraCreator1155PremintExecutor} from "../interfaces/IZoraCreator1155PremintExecutor.sol";
+
+library ZoraCreator1155PremintExecutorImplLib {
+    function getOrCreateContract(
+        IZoraCreator1155Factory zora1155Factory,
+        ContractCreationConfig calldata contractConfig
+    ) internal returns (IZoraCreator1155 tokenContract, bool isNewContract) {
+        address contractAddress = getContractAddress(zora1155Factory, contractConfig);
+        // first we see if the code is already deployed for the contract
+        isNewContract = contractAddress.code.length == 0;
+
+        if (isNewContract) {
+            // if address doesn't exist for hash, create it
+            tokenContract = createContract(zora1155Factory, contractConfig);
+        } else {
+            tokenContract = IZoraCreator1155(contractAddress);
+        }
+    }
+
+    function createContract(
+        IZoraCreator1155Factory zora1155Factory,
+        ContractCreationConfig calldata contractConfig
+    ) internal returns (IZoraCreator1155 tokenContract) {
+        // we need to build the setup actions, that must:
+        bytes[] memory setupActions = new bytes[](0);
+
+        // create the contract via the factory.
+        address newContractAddresss = zora1155Factory.createContractDeterministic(
+            contractConfig.contractURI,
+            contractConfig.contractName,
+            // default royalty config is empty, since we set it on a token level
+            ICreatorRoyaltiesControl.RoyaltyConfiguration({royaltyBPS: 0, royaltyRecipient: address(0), royaltyMintSchedule: 0}),
+            payable(contractConfig.contractAdmin),
+            setupActions
+        );
+        tokenContract = IZoraCreator1155(newContractAddresss);
+    }
+
+    /// Gets the deterministic contract address for the given contract creation config.
+    /// Contract address is generated deterministically from a hash based on the contract uri, contract name,
+    /// contract admin, and the msg.sender, which is this contract's address.
+    function getContractAddress(IZoraCreator1155Factory zora1155Factory, ContractCreationConfig calldata contractConfig) internal view returns (address) {
+        return
+            zora1155Factory.deterministicContractAddress(address(this), contractConfig.contractURI, contractConfig.contractName, contractConfig.contractAdmin);
+    }
+
+    function encodeMintArguments(address mintRecipient, string memory mintComment) internal pure returns (bytes memory) {
+        return abi.encode(mintRecipient, mintComment);
+    }
+
+    function decodeMintArguments(bytes memory mintArguments) internal pure returns (address mintRecipient, string memory mintComment) {
+        return abi.decode(mintArguments, (address, string));
+    }
+
+    function premint(
+        IZoraCreator1155Factory zora1155Factory,
+        ContractCreationConfig calldata contractConfig,
+        bytes memory encodedPremintConfig,
+        bytes32 premintVersion,
+        bytes calldata signature,
+        uint256 quantityToMint,
+        address fixedPriceMinter,
+        IZoraCreator1155PremintExecutor.MintArguments memory mintArguments
+    ) internal returns (IZoraCreator1155PremintExecutor.PremintResult memory) {
+        // get or create the contract with the given params
+        // contract address is deterministic.
+        (IZoraCreator1155 tokenContract, bool isNewContract) = getOrCreateContract(zora1155Factory, contractConfig);
+
+        // pass the signature and the premint config to the token contract to create the token.
+        // The token contract will verify the signature and that the signer has permission to create a new token.
+        // and then create and setup the token using the given token config.
+        uint256 newTokenId = tokenContract.delegateSetupNewToken(encodedPremintConfig, premintVersion, signature, msg.sender);
+
+        _performMint(tokenContract, fixedPriceMinter, newTokenId, quantityToMint, mintArguments);
+
+        return IZoraCreator1155PremintExecutor.PremintResult({contractAddress: address(tokenContract), tokenId: newTokenId, createdNewContract: isNewContract});
+    }
+
+    function _performMint(
+        IZoraCreator1155 tokenContract,
+        address fixedPriceMinter,
+        uint256 tokenId,
+        uint256 quantityToMint,
+        IZoraCreator1155PremintExecutor.MintArguments memory mintArguments
+    ) internal {
+        bytes memory mintSettings = abi.encode(mintArguments.mintRecipient, mintArguments.mintComment);
+        if (quantityToMint != 0)
+            // mint the number of specified tokens to the executor
+            tokenContract.mintWithRewards{value: msg.value}(IMinter1155(fixedPriceMinter), tokenId, quantityToMint, mintSettings, mintArguments.mintReferral);
+    }
+}

--- a/packages/1155-contracts/src/interfaces/IZoraCreator1155.sol
+++ b/packages/1155-contracts/src/interfaces/IZoraCreator1155.sol
@@ -10,7 +10,7 @@ import {IMinter1155} from "../interfaces/IMinter1155.sol";
 import {IOwnable} from "../interfaces/IOwnable.sol";
 import {IVersionedContract} from "./IVersionedContract.sol";
 import {ICreatorRoyaltiesControl} from "../interfaces/ICreatorRoyaltiesControl.sol";
-import {PremintConfig} from "../delegation/ZoraCreator1155Attribution.sol";
+import {PremintConfigV2} from "../delegation/ZoraCreator1155Attribution.sol";
 
 /*
 
@@ -103,7 +103,12 @@ interface IZoraCreator1155 is IZoraCreator1155TypesV1, IZoraCreator1155Errors, I
 
     function getCreatorRewardRecipient(uint256 tokenId) external view returns (address);
 
-    function delegateSetupNewToken(PremintConfig calldata premintConfig, bytes calldata signature, address sender) external returns (uint256 newTokenId);
+    function delegateSetupNewToken(
+        bytes memory premintConfigEncoded,
+        bytes32 premintVersion,
+        bytes calldata signature,
+        address sender
+    ) external returns (uint256 newTokenId);
 
     function updateTokenURI(uint256 tokenId, string memory _newURI) external;
 

--- a/packages/1155-contracts/src/interfaces/IZoraCreator1155PremintExecutor.sol
+++ b/packages/1155-contracts/src/interfaces/IZoraCreator1155PremintExecutor.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {PremintEncoding, ZoraCreator1155Attribution, ContractCreationConfig, PremintConfig, PremintConfigV2, TokenCreationConfig, TokenCreationConfigV2} from "../delegation/ZoraCreator1155Attribution.sol";
+import {IZoraCreator1155Factory} from "./IZoraCreator1155Factory.sol";
+
+// interface for legacy v1 of premint executor methods
+// maintained in order to not break existing calls
+// to legacy api when this api is upgraded
+interface ILegacyZoraCreator1155PremintExecutor {
+    event Preminted(
+        address indexed contractAddress,
+        uint256 indexed tokenId,
+        bool indexed createdNewContract,
+        uint32 uid,
+        ContractCreationConfig contractConfig,
+        TokenCreationConfig tokenConfig,
+        address minter,
+        uint256 quantityMinted
+    );
+
+    function premint(
+        ContractCreationConfig calldata contractConfig,
+        PremintConfig calldata premintConfig,
+        bytes calldata signature,
+        uint256 quantityToMint,
+        string calldata mintComment
+    ) external payable returns (uint256 newTokenId);
+}
+
+interface IZoraCreator1155PremintExecutorV1 {
+    function premintV1(
+        ContractCreationConfig calldata contractConfig,
+        PremintConfig calldata premintConfig,
+        bytes calldata signature,
+        uint256 quantityToMint,
+        IZoraCreator1155PremintExecutor.MintArguments calldata mintArguments
+    ) external payable returns (IZoraCreator1155PremintExecutor.PremintResult memory);
+
+    function isValidSignatureV1(
+        address originalContractAdmin,
+        address contractAddress,
+        PremintConfig calldata premintConfig,
+        bytes calldata signature
+    ) external view returns (bool isValid, address recoveredSigner);
+}
+
+interface IZoraCreator1155PremintExecutorV2 {
+    function premintV2(
+        ContractCreationConfig calldata contractConfig,
+        PremintConfigV2 calldata premintConfig,
+        bytes calldata signature,
+        uint256 quantityToMint,
+        IZoraCreator1155PremintExecutor.MintArguments calldata mintArguments
+    ) external payable returns (IZoraCreator1155PremintExecutor.PremintResult memory);
+
+    function isValidSignatureV2(
+        address originalContractAdmin,
+        address contractAddress,
+        PremintConfigV2 calldata premintConfig,
+        bytes calldata signature
+    ) external view returns (bool isValid, address recoveredSigner);
+}
+
+interface IZoraCreator1155PremintExecutor is IZoraCreator1155PremintExecutorV1, IZoraCreator1155PremintExecutorV2 {
+    struct MintArguments {
+        address mintRecipient;
+        string mintComment;
+        address mintReferral;
+    }
+
+    struct PremintResult {
+        address contractAddress;
+        uint256 tokenId;
+        bool createdNewContract;
+    }
+
+    event PremintedV2(
+        address indexed contractAddress,
+        uint256 indexed tokenId,
+        bool indexed createdNewContract,
+        uint32 uid,
+        address minter,
+        uint256 quantityMinted
+    );
+
+    function zora1155Factory() external view returns (IZoraCreator1155Factory);
+
+    function getContractAddress(ContractCreationConfig calldata contractConfig) external view returns (address);
+}

--- a/packages/1155-contracts/test/fixtures/Zora1155PremintFixtures.sol
+++ b/packages/1155-contracts/test/fixtures/Zora1155PremintFixtures.sol
@@ -5,36 +5,50 @@ import {ZoraCreator1155Impl} from "../../src/nft/ZoraCreator1155Impl.sol";
 import {ZoraCreatorFixedPriceSaleStrategy} from "../../src/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.sol";
 import {IZoraCreator1155Errors} from "../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IMinter1155} from "../../src/interfaces/IMinter1155.sol";
-import {ICreatorRoyaltiesControl} from "../../src/interfaces/ICreatorRoyaltiesControl.sol";
 import {Zora1155Factory} from "../../src/proxies/Zora1155Factory.sol";
 import {ZoraCreator1155FactoryImpl} from "../../src/factory/ZoraCreator1155FactoryImpl.sol";
 import {ProtocolRewards} from "@zoralabs/protocol-rewards/src/ProtocolRewards.sol";
 import {ProxyShim} from "../../src/utils/ProxyShim.sol";
-import {ContractCreationConfig, TokenCreationConfig, PremintConfig} from "../../src/delegation/ZoraCreator1155Attribution.sol";
+import {ContractCreationConfig, TokenCreationConfigV2} from "../../src/delegation/ZoraCreator1155Attribution.sol";
 
 library Zora1155PremintFixtures {
     function makeDefaultContractCreationConfig(address contractAdmin) internal pure returns (ContractCreationConfig memory) {
         return ContractCreationConfig({contractAdmin: contractAdmin, contractName: "blah", contractURI: "blah.contract"});
     }
 
-    function defaultRoyaltyConfig(address royaltyRecipient) internal pure returns (ICreatorRoyaltiesControl.RoyaltyConfiguration memory) {
-        return ICreatorRoyaltiesControl.RoyaltyConfiguration({royaltyBPS: 10, royaltyRecipient: royaltyRecipient, royaltyMintSchedule: 0});
+    function makeDefaultTokenCreationConfigV2(IMinter1155 fixedPriceMinter, address royaltyRecipient) internal pure returns (TokenCreationConfigV2 memory) {
+        return
+            TokenCreationConfigV2({
+                tokenURI: "blah.token",
+                maxSupply: 20,
+                maxTokensPerAddress: 10,
+                pricePerToken: 0,
+                mintStart: 0,
+                mintDuration: 0,
+                fixedPriceMinter: address(fixedPriceMinter),
+                payoutRecipient: royaltyRecipient,
+                royaltyBPS: 0,
+                createReferral: address(0)
+            });
     }
 
-    function makeDefaultTokenCreationConfig(IMinter1155 fixedPriceMinter, address royaltyRecipient) internal pure returns (TokenCreationConfig memory) {
-        ICreatorRoyaltiesControl.RoyaltyConfiguration memory royaltyConfig = defaultRoyaltyConfig(royaltyRecipient);
+    function makeTokenCreationConfigV2WithCreateReferral(
+        IMinter1155 fixedPriceMinter,
+        address createReferral,
+        address royaltyRecipient
+    ) internal pure returns (TokenCreationConfigV2 memory) {
         return
-            TokenCreationConfig({
+            TokenCreationConfigV2({
                 tokenURI: "blah.token",
                 maxSupply: 10,
                 maxTokensPerAddress: 5,
                 pricePerToken: 0,
                 mintStart: 0,
                 mintDuration: 0,
-                royaltyMintSchedule: royaltyConfig.royaltyMintSchedule,
-                royaltyBPS: royaltyConfig.royaltyBPS,
-                royaltyRecipient: royaltyConfig.royaltyRecipient,
-                fixedPriceMinter: address(fixedPriceMinter)
+                fixedPriceMinter: address(fixedPriceMinter),
+                payoutRecipient: royaltyRecipient,
+                royaltyBPS: 10,
+                createReferral: createReferral
             });
     }
 }

--- a/packages/1155-contracts/test/nft/ZoraCreator1155.t.sol
+++ b/packages/1155-contracts/test/nft/ZoraCreator1155.t.sol
@@ -11,8 +11,8 @@ import {ITransferHookReceiver} from "../../src/interfaces/ITransferHookReceiver.
 import {Zora1155} from "../../src/proxies/Zora1155.sol";
 import {ZoraCreatorFixedPriceSaleStrategy} from "../../src/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.sol";
 import {UpgradeGate} from "../../src/upgrades/UpgradeGate.sol";
-import {PremintConfig, TokenCreationConfig} from "../../src/delegation/ZoraCreator1155Attribution.sol";
-import {ZoraCreator1155Attribution} from "../../src/delegation/ZoraCreator1155Attribution.sol";
+import {PremintConfigV2, TokenCreationConfigV2} from "../../src/delegation/ZoraCreator1155Attribution.sol";
+import {ZoraCreator1155Attribution, PremintEncoding} from "../../src/delegation/ZoraCreator1155Attribution.sol";
 
 import {IZoraCreator1155Errors} from "../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IZoraCreator1155} from "../../src/interfaces/IZoraCreator1155.sol";
@@ -38,7 +38,7 @@ contract MockTransferHookReceiver is ITransferHookReceiver {
         hasTransfer[id] = true;
     }
 
-    function supportsInterface(bytes4 testInterface) external pure override returns (bool) {
+    function supportsInterface(bytes4 testInterface) external view override returns (bool) {
         return testInterface == type(ITransferHookReceiver).interfaceId;
     }
 }
@@ -1049,8 +1049,8 @@ contract ZoraCreator1155Test is Test {
 
         init();
 
-        PremintConfig memory premintConfig = PremintConfig({
-            tokenConfig: TokenCreationConfig({
+        PremintConfigV2 memory premintConfig = PremintConfigV2({
+            tokenConfig: TokenCreationConfigV2({
                 // Metadata URI for the created token
                 tokenURI: "",
                 // Max supply of the created token
@@ -1063,14 +1063,12 @@ contract ZoraCreator1155Test is Test {
                 mintStart: 0,
                 // The duration of the mint, starting from the first mint of this token. 0 for infinite
                 mintDuration: type(uint64).max - 1,
-                // RoyaltyMintSchedule for created tokens. Every nth token will go to the royalty recipient.
-                royaltyMintSchedule: 0,
-                // RoyaltyBPS for created tokens. The royalty amount in basis points for secondary sales.
+                payoutRecipient: admin,
                 royaltyBPS: 0,
-                // RoyaltyRecipient for created tokens. The address that will receive the royalty payments.
-                royaltyRecipient: address(0),
                 // Fixed price minter address
-                fixedPriceMinter: address(fixedPriceMinter)
+                fixedPriceMinter: address(fixedPriceMinter),
+                // Default create referral
+                createReferral: address(0)
             }),
             // Unique id of the token, used to ensure that multiple signatures can't be used to create the same intended token.
             // only one signature per token id, scoped to the contract hash can be executed.
@@ -1091,12 +1089,25 @@ contract ZoraCreator1155Test is Test {
             chainId := chainid()
         }
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(adminKey, ZoraCreator1155Attribution.premintHashedTypeDataV4(premintConfig, address(target), chainId));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            adminKey,
+            ZoraCreator1155Attribution.premintHashedTypeDataV4(
+                ZoraCreator1155Attribution.hashPremint(premintConfig),
+                address(target),
+                ZoraCreator1155Attribution.HASHED_VERSION_2,
+                chainId
+            )
+        );
 
         bytes memory signature = abi.encodePacked(r, s, v);
 
         vm.prank(collector);
-        uint256 tokenId = target.delegateSetupNewToken(premintConfig, signature, collectors[0]);
+        uint256 tokenId;
+
+        {
+            (bytes memory premintConfigEncoded, bytes32 version) = PremintEncoding.encodePremintV2(premintConfig);
+            tokenId = target.delegateSetupNewToken(premintConfigEncoded, version, signature, collectors[0]);
+        }
 
         RewardsSettings memory settings = target.computeFreeMintRewards(quantity);
 

--- a/packages/1155-contracts/test/premint/Zora1155PremintExecutorProxy.t.sol
+++ b/packages/1155-contracts/test/premint/Zora1155PremintExecutorProxy.t.sol
@@ -11,9 +11,11 @@ import {ZoraCreator1155PremintExecutorImpl} from "../../src/delegation/ZoraCreat
 import {Zora1155Factory} from "../../src/proxies/Zora1155Factory.sol";
 import {IMinter1155} from "../../src/interfaces/IMinter1155.sol";
 import {ProxyShim} from "../../src/utils/ProxyShim.sol";
-import {ZoraCreator1155Attribution, ContractCreationConfig, TokenCreationConfig, PremintConfig} from "../../src/delegation/ZoraCreator1155Attribution.sol";
+import {ZoraCreator1155Attribution, ContractCreationConfig, TokenCreationConfigV2, PremintConfigV2} from "../../src/delegation/ZoraCreator1155Attribution.sol";
 import {IOwnable2StepUpgradeable} from "../../src/utils/ownable/IOwnable2StepUpgradeable.sol";
 import {IHasContractName} from "../../src/interfaces/IContractMetadata.sol";
+import {ZoraCreator1155PremintExecutorImplLib} from "../../src/delegation/ZoraCreator1155PremintExecutorImplLib.sol";
+import {IZoraCreator1155PremintExecutor} from "../../src/interfaces/IZoraCreator1155PremintExecutor.sol";
 
 contract Zora1155PremintExecutorProxyTest is Test, IHasContractName {
     address internal owner;
@@ -25,6 +27,8 @@ contract Zora1155PremintExecutorProxyTest is Test, IHasContractName {
     ZoraCreator1155FactoryImpl factoryAtProxy;
     uint256 internal mintFeeAmount = 0.000777 ether;
     ZoraCreator1155PremintExecutorImpl preminterAtProxy;
+
+    IZoraCreator1155PremintExecutor.MintArguments defaultMintArguments;
 
     function setUp() external {
         zora = makeAddr("zora");
@@ -46,14 +50,16 @@ contract Zora1155PremintExecutorProxyTest is Test, IHasContractName {
         // access the executor implementation via the proxy, and initialize the admin
         preminterAtProxy = ZoraCreator1155PremintExecutorImpl(address(proxy));
         preminterAtProxy.initialize(owner);
+
+        defaultMintArguments = IZoraCreator1155PremintExecutor.MintArguments({mintRecipient: collector, mintComment: "blah", mintReferral: address(0)});
     }
 
     function test_canInvokeImplementationMethods() external {
         // create premint config
         IMinter1155 fixedPriceMinter = ZoraCreator1155FactoryImpl(address(factoryProxy)).fixedPriceMinter();
 
-        PremintConfig memory premintConfig = PremintConfig({
-            tokenConfig: Zora1155PremintFixtures.makeDefaultTokenCreationConfig(fixedPriceMinter, creator),
+        PremintConfigV2 memory premintConfig = PremintConfigV2({
+            tokenConfig: Zora1155PremintFixtures.makeDefaultTokenCreationConfigV2(fixedPriceMinter, creator),
             uid: 100,
             version: 0,
             deleted: false
@@ -64,7 +70,13 @@ contract Zora1155PremintExecutorProxyTest is Test, IHasContractName {
         address deterministicAddress = preminterAtProxy.getContractAddress(contractConfig);
 
         // sign the premint
-        bytes32 digest = ZoraCreator1155Attribution.premintHashedTypeDataV4(premintConfig, deterministicAddress, block.chainid);
+        bytes32 structHash = ZoraCreator1155Attribution.hashPremint(premintConfig);
+        bytes32 digest = ZoraCreator1155Attribution.premintHashedTypeDataV4(
+            structHash,
+            deterministicAddress,
+            ZoraCreator1155Attribution.HASHED_VERSION_2,
+            block.chainid
+        );
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(creatorPrivateKey, digest);
 
@@ -75,7 +87,8 @@ contract Zora1155PremintExecutorProxyTest is Test, IHasContractName {
         // execute the premint
         vm.deal(collector, mintFeeAmount);
         vm.prank(collector);
-        uint256 tokenId = preminterAtProxy.premint{value: mintFeeAmount}(contractConfig, premintConfig, signature, quantityToMint, "");
+        uint256 tokenId = preminterAtProxy
+        .premintV2{value: mintFeeAmount}(contractConfig, premintConfig, signature, quantityToMint, defaultMintArguments).tokenId;
 
         assertEq(ZoraCreator1155Impl(deterministicAddress).balanceOf(collector, tokenId), 1);
     }

--- a/packages/protocol-deployments/script/DeployProxiesToNewChain.s.sol
+++ b/packages/protocol-deployments/script/DeployProxiesToNewChain.s.sol
@@ -31,7 +31,7 @@ contract DeployProxiesToNewChain is ZoraDeployerBase, DeploymentTestingUtils {
 
         console2.log("testing premint");
 
-        signAndExecutePremint(deployment.preminterProxy);
+        signAndExecutePremint(deployment.preminterProxy, vm.envAddress("TEST_PREMINT_FUNDS_RECIPIENT"));
 
         vm.stopBroadcast();
 

--- a/packages/protocol-deployments/src/DeploymentTestingUtils.sol
+++ b/packages/protocol-deployments/src/DeploymentTestingUtils.sol
@@ -3,32 +3,33 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
 import {IMinter1155} from "@zoralabs/zora-1155-contracts/src/interfaces/IMinter1155.sol";
+import {IZoraCreator1155PremintExecutor} from "@zoralabs/zora-1155-contracts/src/interfaces/IZoraCreator1155PremintExecutor.sol";
 import {ZoraCreator1155PremintExecutorImpl} from "@zoralabs/zora-1155-contracts/src/delegation/ZoraCreator1155PremintExecutorImpl.sol";
 import {ZoraCreator1155FactoryImpl} from "@zoralabs/zora-1155-contracts/src/factory/ZoraCreator1155FactoryImpl.sol";
-import {ZoraCreator1155Attribution, ContractCreationConfig, PremintConfig, TokenCreationConfig} from "@zoralabs/zora-1155-contracts/src/delegation/ZoraCreator1155Attribution.sol";
+import {ZoraCreator1155Attribution, ContractCreationConfig, PremintConfigV2, TokenCreationConfigV2} from "@zoralabs/zora-1155-contracts/src/delegation/ZoraCreator1155Attribution.sol";
 import {ZoraCreator1155Impl} from "@zoralabs/zora-1155-contracts/src/nft/ZoraCreator1155Impl.sol";
 
 contract DeploymentTestingUtils is Script {
-    function signAndExecutePremint(address premintExecutorProxyAddress) internal {
+    function signAndExecutePremint(address premintExecutorProxyAddress, address payoutRecipient) internal {
         console2.log("preminter proxy", premintExecutorProxyAddress);
 
         (address creator, uint256 creatorPrivateKey) = makeAddrAndKey("creator");
-        ZoraCreator1155PremintExecutorImpl preminterAtProxy = ZoraCreator1155PremintExecutorImpl(premintExecutorProxyAddress);
+        IZoraCreator1155PremintExecutor preminterAtProxy = IZoraCreator1155PremintExecutor(premintExecutorProxyAddress);
 
         IMinter1155 fixedPriceMinter = ZoraCreator1155FactoryImpl(address(preminterAtProxy.zora1155Factory())).fixedPriceMinter();
 
-        PremintConfig memory premintConfig = PremintConfig({
-            tokenConfig: TokenCreationConfig({
+        PremintConfigV2 memory premintConfig = PremintConfigV2({
+            tokenConfig: TokenCreationConfigV2({
                 tokenURI: "blah.token",
                 maxSupply: 10,
                 maxTokensPerAddress: 5,
                 pricePerToken: 0,
                 mintStart: 0,
                 mintDuration: 0,
-                royaltyMintSchedule: 0,
                 royaltyBPS: 100,
-                royaltyRecipient: creator,
-                fixedPriceMinter: address(fixedPriceMinter)
+                payoutRecipient: payoutRecipient,
+                fixedPriceMinter: address(fixedPriceMinter),
+                createReferral: address(0)
             }),
             uid: 100,
             version: 0,
@@ -39,18 +40,31 @@ contract DeploymentTestingUtils is Script {
         ContractCreationConfig memory contractConfig = ContractCreationConfig({contractAdmin: creator, contractName: "blah", contractURI: "blah.contract"});
         address deterministicAddress = preminterAtProxy.getContractAddress(contractConfig);
 
-        // sign the premint
-        bytes32 digest = ZoraCreator1155Attribution.premintHashedTypeDataV4(premintConfig, deterministicAddress, block.chainid);
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(creatorPrivateKey, digest);
-
         uint256 quantityToMint = 1;
 
-        bytes memory signature = abi.encodePacked(r, s, v);
+        address mintRecipient = creator;
+
+        IZoraCreator1155PremintExecutor.MintArguments memory mintArguments = IZoraCreator1155PremintExecutor.MintArguments({
+            mintRecipient: mintRecipient,
+            mintComment: "",
+            mintReferral: address(0)
+        });
+
+        bytes memory signature = signPremint(premintConfig, deterministicAddress, creatorPrivateKey);
 
         // execute the premint
-        uint256 tokenId = preminterAtProxy.premint{value: 0.000777 ether}(contractConfig, premintConfig, signature, quantityToMint, "");
+        uint256 tokenId = preminterAtProxy.premintV2{value: 0.000777 ether}(contractConfig, premintConfig, signature, quantityToMint, mintArguments).tokenId;
 
         require(ZoraCreator1155Impl(deterministicAddress).delegatedTokenId(premintConfig.uid) == tokenId, "token id not created for uid");
+    }
+
+    function signPremint(PremintConfigV2 memory premintConfig, address deterministicAddress, uint256 privateKey) private view returns (bytes memory signature) {
+        bytes32 signatureVersion = ZoraCreator1155Attribution.HASHED_VERSION_2;
+        bytes32 structHash = ZoraCreator1155Attribution.hashPremint(premintConfig);
+        // sign the premint
+        bytes32 digest = ZoraCreator1155Attribution.premintHashedTypeDataV4(structHash, deterministicAddress, signatureVersion, block.chainid);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return abi.encodePacked(r, s, v);
     }
 }

--- a/packages/protocol-deployments/test/ZoraCreator1155PremintExecutorForkTest.t.sol
+++ b/packages/protocol-deployments/test/ZoraCreator1155PremintExecutorForkTest.t.sol
@@ -76,7 +76,12 @@ contract ZoraCreator1155PreminterForkTest is ForkDeploymentConfig, Test {
         uint256 privateKey,
         uint256 chainId
     ) private pure returns (bytes memory) {
-        bytes32 digest = ZoraCreator1155Attribution.premintHashedTypeDataV4(premintConfig, contractAddress, chainId);
+        bytes32 digest = ZoraCreator1155Attribution.premintHashedTypeDataV4(
+            ZoraCreator1155Attribution.hashPremint(premintConfig),
+            contractAddress,
+            ZoraCreator1155Attribution.HASHED_VERSION_1,
+            chainId
+        );
 
         // 3. Sign the digest
         // create a signature with the digest for the params

--- a/packages/protocol-sdk/src/premint/preminter.test.ts
+++ b/packages/protocol-sdk/src/premint/preminter.test.ts
@@ -23,7 +23,7 @@ import {
   TokenCreationConfig,
   preminterTypedDataDefinition,
 } from "./preminter";
-import { AnvilViemClientsTest, anvilTest } from "src/anvil";
+import { AnvilViemClientsTest, anvilTest, forkUrls, makeAnvilTest } from "src/anvil";
 
 // create token and contract creation config:
 const defaultContractConfig = ({
@@ -140,7 +140,10 @@ describe("ZoraCreator1155Preminter", () => {
     },
     20 * 1000,
   );
-  anvilTest(
+  makeAnvilTest({
+    forkUrl: forkUrls.zoraGoerli,
+    forkBlockNumber: 1676105
+  })(
     "can sign and recover a signature",
     async ({ viemClients }) => {
       const {
@@ -174,7 +177,7 @@ describe("ZoraCreator1155Preminter", () => {
         account: creatorAccount,
       });
 
-      const preminterAddress = zoraCreator1155FactoryImplAddress[999];
+      const preminterAddress = zoraCreator1155PremintExecutorAddress[999];
       // recover and verify address is correct
       const [,,recoveredAddress] = await viemClients.publicClient.readContract({
         abi: preminterAbi,

--- a/packages/protocol-sdk/src/premint/preminter.test.ts
+++ b/packages/protocol-sdk/src/premint/preminter.test.ts
@@ -174,12 +174,13 @@ describe("ZoraCreator1155Preminter", () => {
         account: creatorAccount,
       });
 
+      const preminterAddress = zoraCreator1155FactoryImplAddress[999];
       // recover and verify address is correct
-      const recoveredAddress = await viemClients.publicClient.readContract({
+      const [,,recoveredAddress] = await viemClients.publicClient.readContract({
         abi: preminterAbi,
-        address: PREMINTER_ADDRESS,
-        functionName: "recoverSigner",
-        args: [premintConfig, contractAddress, signedMessage],
+        address: preminterAddress,
+        functionName: "isValidSignature",
+        args: [contractConfig, premintConfig, signedMessage],
       });
 
       expect(recoveredAddress).to.equal(creatorAccount);
@@ -286,6 +287,7 @@ describe("ZoraCreator1155Preminter", () => {
         args: [contractAddress, premintConfig.uid],
       });
 
+      expect(contractCreated).toBe(true);
       expect(tokenId).not.toBe(0n);
 
       // now use what was created, to get the balance from the created contract

--- a/packages/protocol-sdk/src/premint/preminter.test.ts
+++ b/packages/protocol-sdk/src/premint/preminter.test.ts
@@ -23,7 +23,12 @@ import {
   TokenCreationConfig,
   preminterTypedDataDefinition,
 } from "./preminter";
-import { AnvilViemClientsTest, anvilTest, forkUrls, makeAnvilTest } from "src/anvil";
+import {
+  AnvilViemClientsTest,
+  anvilTest,
+  forkUrls,
+  makeAnvilTest,
+} from "src/anvil";
 
 // create token and contract creation config:
 const defaultContractConfig = ({
@@ -142,7 +147,7 @@ describe("ZoraCreator1155Preminter", () => {
   );
   makeAnvilTest({
     forkUrl: forkUrls.zoraGoerli,
-    forkBlockNumber: 1676105
+    forkBlockNumber: 1676105,
   })(
     "can sign and recover a signature",
     async ({ viemClients }) => {
@@ -179,12 +184,13 @@ describe("ZoraCreator1155Preminter", () => {
 
       const preminterAddress = zoraCreator1155PremintExecutorAddress[999];
       // recover and verify address is correct
-      const [,,recoveredAddress] = await viemClients.publicClient.readContract({
-        abi: preminterAbi,
-        address: preminterAddress,
-        functionName: "isValidSignature",
-        args: [contractConfig, premintConfig, signedMessage],
-      });
+      const [, , recoveredAddress] =
+        await viemClients.publicClient.readContract({
+          abi: preminterAbi,
+          address: preminterAddress,
+          functionName: "isValidSignature",
+          args: [contractConfig, premintConfig, signedMessage],
+        });
 
       expect(recoveredAddress).to.equal(creatorAccount);
     },


### PR DESCRIPTION
Premint v2 - adding a new signature, where `createReferral` can be specified.  `ZoraCreator1155PremintExecutor` recognizes new version of the signature, and still works with the v1 (legacy) version of the signature.  1155 contract has been updated to now take abi encoded premint config, premint config version, and send it to an external library to decode the config, the signer, and setup actions.

ZoraCreator1155PremintExecutor can now validate signatures by passing it the contract address, instead of needing to pass the full contract creation config, enabling it to validate signatures for 1155 contracts that were not created via the premint executor contract.  This allows premints signatures to be validated on contracts that have been upgrade to a version that supports premints, and allows premints to be created on contracts that were not created via the premint executor contract.

1155 contract has been updated to now take abi encoded premint config, premint config version, and send it to an external library to decode the config, the signer, and setup actions.  

changes to `ZoraCreator1155PremintExecutorImpl`:

`PremintConfigV2` are updated to containe `createReferral`, and now look like:
```solidity
struct PremintConfigV2 {
    // The config for the token to be created
    TokenCreationConfigV2 tokenConfig;
    // Unique id of the token, used to ensure that multiple signatures can't be used to create the same intended token.
    // only one signature per token id, scoped to the contract hash can be executed.
    uint32 uid;
    // Version of this premint, scoped to the uid and contract.  Not used for logic in the contract, but used externally to track the newest version
    uint32 version;
    // If executing this signature results in preventing any signature with this uid from being minted.
    bool deleted;
}

struct TokenCreationConfigV2 {
    // Metadata URI for the created token
    string tokenURI;
    // Max supply of the created token
    uint256 maxSupply;
    // Max tokens that can be minted for an address, 0 if unlimited
    uint64 maxTokensPerAddress;
    // Price per token in eth wei. 0 for a free mint.
    uint96 pricePerToken;
    // The start time of the mint, 0 for immediate.  Prevents signatures from being used until the start time.
    uint64 mintStart;
    // The duration of the mint, starting from the first mint of this token. 0 for infinite
    uint64 mintDuration;
    // RoyaltyBPS for created tokens. The royalty amount in basis points for secondary sales.
    uint32 royaltyBPS;
    // The address that will receive creatorRewards, secondary royalties, and paid mint funds.
    address payoutAddress;
    // Fixed price minter address
    address fixedPriceMinter;
    // create referral
    address createReferral;
}
```
`PremintConfig` fields are **the same as they were before, but are treated as a version 1**:

```solidity
struct PremintConfig {
    // The config for the token to be created
    TokenCreationConfig tokenConfig;
    // Unique id of the token, used to ensure that multiple signatures can't be used to create the same intended token.
    // only one signature per token id, scoped to the contract hash can be executed.
    uint32 uid;
    // Version of this premint, scoped to the uid and contract.  Not used for logic in the contract, but used externally to track the newest version
    uint32 version;
    // If executing this signature results in preventing any signature with this uid from being minted.
    bool deleted;
}

struct TokenCreationConfig {
    // Metadata URI for the created token
    string tokenURI;
    // Max supply of the created token
    uint256 maxSupply;
    // Max tokens that can be minted for an address, 0 if unlimited
    uint64 maxTokensPerAddress;
    // Price per token in eth wei. 0 for a free mint.
    uint96 pricePerToken;
    // The start time of the mint, 0 for immediate.  Prevents signatures from being used until the start time.
    uint64 mintStart;
    // The duration of the mint, starting from the first mint of this token. 0 for infinite
    uint64 mintDuration;
    // RoyaltyMintSchedule for created tokens. Every nth token will go to the royalty recipient.
    uint32 royaltyMintSchedule;
    // RoyaltyBPS for created tokens. The royalty amount in basis points for secondary sales.
    uint32 royaltyBPS;
    // RoyaltyRecipient for created tokens. The address that will receive the royalty payments.
    address royaltyRecipient;
    // Fixed price minter address
    address fixedPriceMinter;
}
```

changes to `ZoraCreator1155PremintExecutorImpl`:
* new function `premintV1` - takes a `PremintConfig`, and premint v1 signature, and executes a premint, with added functionality of being able to specify mint referral and mint recipient
* new function `premintV2` - takes a `PremintConfigV2` signature and executes a premint, with being able to specify mint referral and mint recipient
* deprecated function `premint` - call `premintV1` instead
* new function `isValidSignatureV1` - takes an 1155 address, contract admin, premint v1 config and signature,  and validates the signature.  Can be used for 1155 contracts that were not created via the premint executor contract.
* new function `isValidSignatureV2` - takes an 1155 address, contract admin, premint v2 config and signature,  and validates the signature.  Can be used for 1155 contracts that were not created via the premint executor contract.
* deprecated function `isValidSignature` - call `isValidSignatureV1` instead