### PR TITLE
Premint - rename royaltyRecipient to creatorRewardsAndRoyaltyRecipient on premint v2 signature

### DIFF
--- a/.changeset/violet-starfishes-visit.md
+++ b/.changeset/violet-starfishes-visit.md
@@ -39,8 +39,8 @@ struct TokenCreationConfigV2 {
     uint64 mintDuration;
     // RoyaltyBPS for created tokens. The royalty amount in basis points for secondary sales.
     uint32 royaltyBPS;
-    // funds for created tokens. The address that will receive creatorRewards, secondary royalties, and paid mint funds.
-    address royaltyRecipient;
+    // The address that will receive creatorRewards, secondary royalties, and paid mint funds.
+    address payoutAddress;
     // Fixed price minter address
     address fixedPriceMinter;
     // create referral

--- a/packages/1155-contracts/src/delegation/ZoraCreator1155Attribution.sol
+++ b/packages/1155-contracts/src/delegation/ZoraCreator1155Attribution.sol
@@ -80,7 +80,7 @@ struct TokenCreationConfigV2 {
     // RoyaltyBPS for created tokens. The royalty amount in basis points for secondary sales.
     uint32 royaltyBPS;
     // The address that will receive creatorRewards, secondary royalties, and paid mint funds.
-    address royaltyRecipient;
+    address payoutAddress;
     // Fixed price minter address
     address fixedPriceMinter;
     // create referral
@@ -195,7 +195,7 @@ library ZoraCreator1155Attribution {
 
     bytes32 constant TOKEN_DOMAIN_V2 =
         keccak256(
-            "TokenCreationConfig(string tokenURI,uint256 maxSupply,uint64 maxTokensPerAddress,uint96 pricePerToken,uint64 mintStart,uint64 mintDuration,uint32 royaltyBPS,address royaltyRecipient,address fixedPriceMinter,address createReferral)"
+            "TokenCreationConfig(string tokenURI,uint256 maxSupply,uint64 maxTokensPerAddress,uint96 pricePerToken,uint64 mintStart,uint64 mintDuration,uint32 royaltyBPS,address payoutAddress,address fixedPriceMinter,address createReferral)"
         );
 
     function _hashToken(TokenCreationConfigV2 memory tokenConfig) private pure returns (bytes32) {
@@ -210,7 +210,7 @@ library ZoraCreator1155Attribution {
                     tokenConfig.mintStart,
                     tokenConfig.mintDuration,
                     tokenConfig.royaltyBPS,
-                    tokenConfig.royaltyRecipient,
+                    tokenConfig.payoutAddress,
                     tokenConfig.fixedPriceMinter,
                     tokenConfig.createReferral
                 )
@@ -266,7 +266,7 @@ library PremintTokenSetup {
                 maxTokensPerAddress: tokenConfig.maxTokensPerAddress,
                 mintDuration: tokenConfig.mintDuration,
                 royaltyBPS: tokenConfig.royaltyBPS,
-                royaltyRecipient: tokenConfig.royaltyRecipient
+                payoutAddress: tokenConfig.payoutAddress
             });
     }
 
@@ -280,7 +280,7 @@ library PremintTokenSetup {
                 maxTokensPerAddress: tokenConfig.maxTokensPerAddress,
                 mintDuration: tokenConfig.mintDuration,
                 royaltyBPS: tokenConfig.royaltyBPS,
-                royaltyRecipient: tokenConfig.royaltyRecipient
+                payoutAddress: tokenConfig.royaltyRecipient
             });
     }
 
@@ -291,7 +291,7 @@ library PremintTokenSetup {
         uint64 maxTokensPerAddress,
         uint64 mintDuration,
         uint32 royaltyBPS,
-        address royaltyRecipient
+        address payoutAddress
     ) private view returns (bytes[] memory calls) {
         calls = new bytes[](3);
 
@@ -318,7 +318,7 @@ library PremintTokenSetup {
         calls[2] = abi.encodeWithSelector(
             IZoraCreator1155.updateRoyaltiesForToken.selector,
             newTokenId,
-            ICreatorRoyaltiesControl.RoyaltyConfiguration({royaltyBPS: royaltyBPS, royaltyRecipient: royaltyRecipient, royaltyMintSchedule: 0})
+            ICreatorRoyaltiesControl.RoyaltyConfiguration({royaltyBPS: royaltyBPS, royaltyRecipient: payoutAddress, royaltyMintSchedule: 0})
         );
     }
 

--- a/packages/1155-contracts/test/fixtures/Zora1155PremintFixtures.sol
+++ b/packages/1155-contracts/test/fixtures/Zora1155PremintFixtures.sol
@@ -26,7 +26,7 @@ library Zora1155PremintFixtures {
                 mintStart: 0,
                 mintDuration: 0,
                 fixedPriceMinter: address(fixedPriceMinter),
-                royaltyRecipient: royaltyRecipient,
+                payoutAddress: royaltyRecipient,
                 royaltyBPS: 0,
                 createReferral: address(0)
             });
@@ -46,7 +46,7 @@ library Zora1155PremintFixtures {
                 mintStart: 0,
                 mintDuration: 0,
                 fixedPriceMinter: address(fixedPriceMinter),
-                royaltyRecipient: royaltyRecipient,
+                payoutAddress: royaltyRecipient,
                 royaltyBPS: 10,
                 createReferral: createReferral
             });

--- a/packages/1155-contracts/test/nft/ZoraCreator1155.t.sol
+++ b/packages/1155-contracts/test/nft/ZoraCreator1155.t.sol
@@ -1057,7 +1057,7 @@ contract ZoraCreator1155Test is Test {
                 mintStart: 0,
                 // The duration of the mint, starting from the first mint of this token. 0 for infinite
                 mintDuration: type(uint64).max - 1,
-                royaltyRecipient: admin,
+                payoutAddress: admin,
                 royaltyBPS: 0,
                 // Fixed price minter address
                 fixedPriceMinter: address(fixedPriceMinter),


### PR DESCRIPTION
Since royalty recipient is both the creator rewarsd recipient and royalty recipient, this PR renames it to
`creatorRewardsAndRoyaltyRecipient` on the signature, to better imply what it means
