### PR TITLE
Remove warnings from test

### DIFF
--- a/packages/1155-contracts/package.json
+++ b/packages/1155-contracts/package.json
@@ -25,7 +25,7 @@
     "build": "tsup",
     "build:sizes": "forge build --sizes",
     "bundle-configs": "node script/bundle-chainConfigs.mjs && yarn prettier",
-    "wagmi": "wagmi generate",
+    "wagmi": "FOUNDRY_PROFILE=dev forge build && wagmi generate",
     "storage-inspect:check": "./script/storage-check.sh check ZoraCreator1155Impl ZoraCreator1155FactoryImpl",
     "storage-inspect:generate": "./script/storage-check.sh generate ZoraCreator1155Impl ZoraCreator1155FactoryImpl",
     "js-test:watch": "vitest dev",

--- a/packages/1155-contracts/test/nft/ZoraCreator1155.t.sol
+++ b/packages/1155-contracts/test/nft/ZoraCreator1155.t.sol
@@ -28,25 +28,17 @@ import {SimpleRenderer} from "../mock/SimpleRenderer.sol";
 contract MockTransferHookReceiver is ITransferHookReceiver {
     mapping(uint256 => bool) public hasTransfer;
 
-    function onTokenTransferBatch(
-        address target,
-        address operator,
-        address from,
-        address to,
-        uint256[] memory ids,
-        uint256[] memory amounts,
-        bytes memory data
-    ) external {
+    function onTokenTransferBatch(address, address, address, address, uint256[] memory ids, uint256[] memory, bytes memory) external {
         for (uint256 i = 0; i < ids.length; i++) {
             hasTransfer[ids[i]] = true;
         }
     }
 
-    function onTokenTransfer(address target, address operator, address from, address to, uint256 id, uint256 amount, bytes memory data) external {
+    function onTokenTransfer(address, address, address, address, uint256 id, uint256, bytes memory) external {
         hasTransfer[id] = true;
     }
 
-    function supportsInterface(bytes4 testInterface) external view override returns (bool) {
+    function supportsInterface(bytes4 testInterface) external pure override returns (bool) {
         return testInterface == type(ITransferHookReceiver).interfaceId;
     }
 }

--- a/packages/1155-contracts/wagmi.config.ts
+++ b/packages/1155-contracts/wagmi.config.ts
@@ -107,6 +107,9 @@ export default defineConfig({
   plugins: [
     foundry({
       deployments: getAddresses(),
+      forge: {
+        build: false,
+      },
       include: contractFilesToInclude.map(
         (contractName) => `${contractName}.json`
       ),


### PR DESCRIPTION
Remove variable names to get rid of pesky warnings that flood compilation screen
