### PR TITLE
Premint - no operator overloading

### DIFF
--- a/.changeset/violet-starfishes-visit.md
+++ b/.changeset/violet-starfishes-visit.md
@@ -3,3 +3,8 @@
 ---
 
 Premint v2 - for add new signature, where createReferral can be specified.  ZoraCreator1155PremintExecutor recognizes new version of the signature, and still works with the v1 (legacy) version of the signature.  1155 contract has been updated to now take abi encoded premint config, premint config version, and send it to an external library to decode the config, the signer, and setup actions.
+
+changes to `ZoraCreator1155PremintExecutorImpl`:
+* new function `premintV1` - takes a premint v1 signature and executed a premint, with added functionality of being able to specify mint referral and mint recipient
+* new function `premintV2` - takes a premint v2 signature and executes a premint, with being able to specify mint referral and mint recipient
+* deprecated function `premint` - call `premintV1` instead

--- a/packages/1155-contracts/package/preminter.test.ts
+++ b/packages/1155-contracts/package/preminter.test.ts
@@ -198,14 +198,19 @@ describe("ZoraCreator1155Preminter", () => {
       });
 
       // recover and verify address is correct
-      const [, , recoveredAddress] = await publicClient.readContract({
+      const [isValidSignature] = await publicClient.readContract({
         abi: preminterAbi,
         address: preminterAddress,
-        functionName: "isValidSignature",
-        args: [contractConfig, premintConfig, signedMessage],
+        functionName: "isValidSignatureV2",
+        args: [
+          contractConfig.contractAdmin,
+          contractAddress,
+          premintConfig,
+          signedMessage,
+        ],
       });
 
-      expect(recoveredAddress).to.equal(creatorAccount);
+      expect(isValidSignature).toBe(true);
     },
 
     20 * 1000
@@ -277,7 +282,7 @@ describe("ZoraCreator1155Preminter", () => {
       // parameters are required to call this function
       const mintHash = await walletClient.writeContract({
         abi: preminterAbi,
-        functionName: "premint",
+        functionName: "premintV2",
         account: collectorAccount,
         address: preminterAddress,
         args: [
@@ -352,7 +357,7 @@ describe("ZoraCreator1155Preminter", () => {
       // it should create a new token against the existing contract
       const mintHash2 = await walletClient.writeContract({
         abi: preminterAbi,
-        functionName: "premint",
+        functionName: "premintV2",
         account: collectorAccount,
         address: preminterAddress,
         args: [
@@ -450,7 +455,7 @@ describe("ZoraCreator1155Preminter", () => {
     // parameters are required to call this function
     const mintHash = await walletClient.writeContract({
       abi: preminterAbi,
-      functionName: "premint",
+      functionName: "premintV2",
       account: collectorAccount,
       address: preminterAddress,
       args: [

--- a/packages/1155-contracts/package/preminter.ts
+++ b/packages/1155-contracts/package/preminter.ts
@@ -3,26 +3,24 @@ import { ExtractAbiFunction, AbiParametersToPrimitiveTypes } from "abitype";
 import { zoraCreator1155PremintExecutorImplABI as preminterAbi } from "./wagmiGenerated";
 import { TypedDataDefinition } from "viem";
 
-type PremintInputs = ExtractAbiFunction<
+type PremintV1Inputs = ExtractAbiFunction<
   typeof preminterAbi,
-  "premint"
+  "premintV1"
 >["inputs"];
 
-type PreminterHashDataTypes = AbiParametersToPrimitiveTypes<PremintInputs>;
+type PremintV2Inputs = ExtractAbiFunction<
+  typeof preminterAbi,
+  "premintV2"
+>["inputs"];
 
-export type ContractCreationConfig = PreminterHashDataTypes[0];
-export type PremintConfigs = PreminterHashDataTypes[1];
+type PreminterV1HashDataTypes = AbiParametersToPrimitiveTypes<PremintV1Inputs>;
+type PreminterV2HashDataTypes = AbiParametersToPrimitiveTypes<PremintV2Inputs>;
+
+export type ContractCreationConfig = PreminterV2HashDataTypes[0];
+export type PremintConfigV1 = PreminterV1HashDataTypes[1];
+export type PremintConfigV2 = PreminterV2HashDataTypes[1];
 
 export type TokenCreationConfigV1 = PremintConfigV2["tokenConfig"];
-export type PremintConfigV2 = Extract<
-  PremintConfigs,
-  {
-    tokenConfig: {
-      createReferral: string;
-    };
-  }
->;
-export type PremintConfigV1 = Exclude<PremintConfigs, PremintConfigV2>;
 export type TokenCreationConfigV2 = PremintConfigV2["tokenConfig"];
 
 const premintV2Types = {

--- a/packages/1155-contracts/src/deployment/DeploymentTestingUtils.sol
+++ b/packages/1155-contracts/src/deployment/DeploymentTestingUtils.sol
@@ -5,7 +5,8 @@ import "forge-std/Script.sol";
 import {IMinter1155} from "..//interfaces/IMinter1155.sol";
 import {Zora1155FactoryFixtures} from "../../test/fixtures/Zora1155FactoryFixtures.sol";
 import {Zora1155PremintFixtures} from "../../test/fixtures/Zora1155PremintFixtures.sol";
-import {ZoraCreator1155PremintExecutorImpl, MintArguments} from "../delegation/ZoraCreator1155PremintExecutorImpl.sol";
+import {ZoraCreator1155PremintExecutorImpl} from "../delegation/ZoraCreator1155PremintExecutorImpl.sol";
+import {IZoraCreator1155PremintExecutor} from "../interfaces/IZoraCreator1155PremintExecutor.sol";
 import {ZoraCreator1155FactoryImpl} from "../factory/ZoraCreator1155FactoryImpl.sol";
 import {ZoraCreator1155Attribution, ContractCreationConfig, PremintConfigV2} from "../delegation/ZoraCreator1155Attribution.sol";
 import {ZoraCreator1155Impl} from "../nft/ZoraCreator1155Impl.sol";
@@ -16,7 +17,7 @@ contract DeploymentTestingUtils is Script {
         console2.log("preminter proxy", premintExecutorProxyAddress);
 
         (address creator, uint256 creatorPrivateKey) = makeAddrAndKey("creator");
-        ZoraCreator1155PremintExecutorImpl preminterAtProxy = ZoraCreator1155PremintExecutorImpl(premintExecutorProxyAddress);
+        IZoraCreator1155PremintExecutor preminterAtProxy = IZoraCreator1155PremintExecutor(premintExecutorProxyAddress);
 
         IMinter1155 fixedPriceMinter = ZoraCreator1155FactoryImpl(address(preminterAtProxy.zora1155Factory())).fixedPriceMinter();
 
@@ -35,12 +36,16 @@ contract DeploymentTestingUtils is Script {
 
         address mintRecipient = creator;
 
-        MintArguments memory mintArguments = MintArguments({mintRecipient: mintRecipient, mintComment: "", mintReferral: address(0)});
+        IZoraCreator1155PremintExecutor.MintArguments memory mintArguments = IZoraCreator1155PremintExecutor.MintArguments({
+            mintRecipient: mintRecipient,
+            mintComment: "",
+            mintReferral: address(0)
+        });
 
         bytes memory signature = signPremint(premintConfig, deterministicAddress, creatorPrivateKey);
 
         // execute the premint
-        uint256 tokenId = preminterAtProxy.premint{value: 0.000777 ether}(contractConfig, premintConfig, signature, quantityToMint, mintArguments);
+        uint256 tokenId = preminterAtProxy.premintV2{value: 0.000777 ether}(contractConfig, premintConfig, signature, quantityToMint, mintArguments).tokenId;
 
         require(ZoraCreator1155Impl(deterministicAddress).delegatedTokenId(premintConfig.uid) == tokenId, "token id not created for uid");
     }

--- a/packages/1155-contracts/src/interfaces/IZoraCreator1155PremintExecutor.sol
+++ b/packages/1155-contracts/src/interfaces/IZoraCreator1155PremintExecutor.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {PremintEncoding, ZoraCreator1155Attribution, ContractCreationConfig, PremintConfig, PremintConfigV2, TokenCreationConfig, TokenCreationConfigV2} from "../delegation/ZoraCreator1155Attribution.sol";
+import {IZoraCreator1155Factory} from "./IZoraCreator1155Factory.sol";
+
+// interface for legacy v1 of premint executor methods
+// maintained in order to not break existing calls
+// to legacy api when this api is upgraded
+interface ILegacyZoraCreator1155PremintExecutor {
+    event Preminted(
+        address indexed contractAddress,
+        uint256 indexed tokenId,
+        bool indexed createdNewContract,
+        uint32 uid,
+        ContractCreationConfig contractConfig,
+        TokenCreationConfig tokenConfig,
+        address minter,
+        uint256 quantityMinted
+    );
+
+    function premint(
+        ContractCreationConfig calldata contractConfig,
+        PremintConfig calldata premintConfig,
+        bytes calldata signature,
+        uint256 quantityToMint,
+        string calldata mintComment
+    ) external payable returns (uint256 newTokenId);
+}
+
+interface IZoraCreator1155PremintExecutorV1 {
+    function premintV1(
+        ContractCreationConfig calldata contractConfig,
+        PremintConfig calldata premintConfig,
+        bytes calldata signature,
+        uint256 quantityToMint,
+        IZoraCreator1155PremintExecutor.MintArguments calldata mintArguments
+    ) external payable returns (IZoraCreator1155PremintExecutor.PremintResult memory);
+
+    function isValidSignatureV1(
+        address originalContractAdmin,
+        address contractAddress,
+        PremintConfig calldata premintConfig,
+        bytes calldata signature
+    ) external view returns (bool isValid, address recoveredSigner);
+}
+
+interface IZoraCreator1155PremintExecutorV2 {
+    function premintV2(
+        ContractCreationConfig calldata contractConfig,
+        PremintConfigV2 calldata premintConfig,
+        bytes calldata signature,
+        uint256 quantityToMint,
+        IZoraCreator1155PremintExecutor.MintArguments calldata mintArguments
+    ) external payable returns (IZoraCreator1155PremintExecutor.PremintResult memory);
+
+    function isValidSignatureV2(
+        address originalContractAdmin,
+        address contractAddress,
+        PremintConfigV2 calldata premintConfig,
+        bytes calldata signature
+    ) external view returns (bool isValid, address recoveredSigner);
+}
+
+interface IZoraCreator1155PremintExecutor is IZoraCreator1155PremintExecutorV1, IZoraCreator1155PremintExecutorV2 {
+    struct MintArguments {
+        address mintRecipient;
+        string mintComment;
+        address mintReferral;
+    }
+
+    struct PremintResult {
+        address contractAddress;
+        uint256 tokenId;
+        bool createdNewContract;
+    }
+
+    event PremintedV2(
+        address indexed contractAddress,
+        uint256 indexed tokenId,
+        bool indexed createdNewContract,
+        uint32 uid,
+        address minter,
+        uint256 quantityMinted
+    );
+
+    function zora1155Factory() external view returns (IZoraCreator1155Factory);
+
+    function getContractAddress(ContractCreationConfig calldata contractConfig) external view returns (address);
+}

--- a/packages/1155-contracts/src/nft/ZoraCreator1155Impl.sol
+++ b/packages/1155-contracts/src/nft/ZoraCreator1155Impl.sol
@@ -749,8 +749,10 @@ contract ZoraCreator1155Impl is
 
     /// Sets up a new token using a token configuration and a signature created for the token creation parameters.
     /// The signature must be created by an account with the PERMISSION_BIT_MINTER role on the contract.
-    /// @param premintConfig configuration of token to be created
+    /// @param premintConfig abi encoded configuration of token to be created
+    /// @param premintVersion version of the premint configuration
     /// @param signature EIP-712 Signature created on the premintConfig by an account with the PERMISSION_BIT_MINTER role on the contract.
+    /// @param sender original sender of the transaction, used to set the firstMinter
     function delegateSetupNewToken(
         bytes memory premintConfig,
         bytes32 premintVersion,

--- a/packages/1155-contracts/test/premint/Zora1155PremintExecutorProxy.t.sol
+++ b/packages/1155-contracts/test/premint/Zora1155PremintExecutorProxy.t.sol
@@ -7,7 +7,7 @@ import {Zora1155PremintFixtures} from "../fixtures/Zora1155PremintFixtures.sol";
 import {ZoraCreator1155FactoryImpl} from "../../src/factory/ZoraCreator1155FactoryImpl.sol";
 import {Zora1155PremintExecutor} from "../../src/proxies/Zora1155PremintExecutor.sol";
 import {ZoraCreator1155Impl} from "../../src/nft/ZoraCreator1155Impl.sol";
-import {ZoraCreator1155PremintExecutorImpl, MintArguments} from "../../src/delegation/ZoraCreator1155PremintExecutorImpl.sol";
+import {ZoraCreator1155PremintExecutorImpl} from "../../src/delegation/ZoraCreator1155PremintExecutorImpl.sol";
 import {Zora1155Factory} from "../../src/proxies/Zora1155Factory.sol";
 import {IMinter1155} from "../../src/interfaces/IMinter1155.sol";
 import {ProxyShim} from "../../src/utils/ProxyShim.sol";
@@ -15,6 +15,7 @@ import {ZoraCreator1155Attribution, ContractCreationConfig, TokenCreationConfigV
 import {IOwnable2StepUpgradeable} from "../../src/utils/ownable/IOwnable2StepUpgradeable.sol";
 import {IHasContractName} from "../../src/interfaces/IContractMetadata.sol";
 import {ZoraCreator1155PremintExecutorImplLib} from "../../src/delegation/ZoraCreator1155PremintExecutorImplLib.sol";
+import {IZoraCreator1155PremintExecutor} from "../../src/interfaces/IZoraCreator1155PremintExecutor.sol";
 
 contract Zora1155PremintExecutorProxyTest is Test, IHasContractName {
     address internal owner;
@@ -27,7 +28,7 @@ contract Zora1155PremintExecutorProxyTest is Test, IHasContractName {
     uint256 internal mintFeeAmount = 0.000777 ether;
     ZoraCreator1155PremintExecutorImpl preminterAtProxy;
 
-    MintArguments defaultMintArguments;
+    IZoraCreator1155PremintExecutor.MintArguments defaultMintArguments;
 
     function setUp() external {
         zora = makeAddr("zora");
@@ -50,7 +51,7 @@ contract Zora1155PremintExecutorProxyTest is Test, IHasContractName {
         preminterAtProxy = ZoraCreator1155PremintExecutorImpl(address(proxy));
         preminterAtProxy.initialize(owner);
 
-        defaultMintArguments = MintArguments({mintRecipient: collector, mintComment: "blah", mintReferral: address(0)});
+        defaultMintArguments = IZoraCreator1155PremintExecutor.MintArguments({mintRecipient: collector, mintComment: "blah", mintReferral: address(0)});
     }
 
     function test_canInvokeImplementationMethods() external {
@@ -86,7 +87,8 @@ contract Zora1155PremintExecutorProxyTest is Test, IHasContractName {
         // execute the premint
         vm.deal(collector, mintFeeAmount);
         vm.prank(collector);
-        uint256 tokenId = preminterAtProxy.premint{value: mintFeeAmount}(contractConfig, premintConfig, signature, quantityToMint, defaultMintArguments);
+        uint256 tokenId = preminterAtProxy
+        .premintV2{value: mintFeeAmount}(contractConfig, premintConfig, signature, quantityToMint, defaultMintArguments).tokenId;
 
         assertEq(ZoraCreator1155Impl(deterministicAddress).balanceOf(collector, tokenId), 1);
     }


### PR DESCRIPTION
* premint v2 - dont overload external operators, have specific names for each function
* premint validation methods now just take the contract address, allowing them to be used with existing contracts (not requiring contract creation config)
* extracted premint functionality to lib
* Defined interface for premint executor
