### PR TITLE
Add way to unlink contracts before verifying

### DIFF
--- a/packages/1155-contracts/foundry.toml
+++ b/packages/1155-contracts/foundry.toml
@@ -1,5 +1,10 @@
 [profile.default]
-fs_permissions = [{access = "read", path = "./addresses"}, {access = "read", path = "./chainConfigs"}, {access = "read", path = "./package.json"}, {access = "readwrite", path = "./deterministicConfig"}]
+fs_permissions = [
+  { access = "read", path = "./addresses" },
+  { access = "read", path = "./chainConfigs" },
+  { access = "read", path = "./package.json" },
+  { access = "readwrite", path = "./deterministicConfig" },
+]
 libs = ['_imagine', 'node_modules', 'script']
 allow_paths = ["node_modules/@zoralabs/protocol-rewards"]
 optimizer = true

--- a/packages/1155-contracts/package.json
+++ b/packages/1155-contracts/package.json
@@ -29,7 +29,9 @@
     "storage-inspect:check": "./script/storage-check.sh check ZoraCreator1155Impl ZoraCreator1155FactoryImpl",
     "storage-inspect:generate": "./script/storage-check.sh generate ZoraCreator1155Impl ZoraCreator1155FactoryImpl",
     "js-test:watch": "vitest dev",
-    "anvil": "source .env.anvil && anvil --fork-url $FORK_RPC_URL --fork-block-number $FORK_BLOCK_NUMBER --chain-id 31337"
+    "anvil": "source .env.anvil && anvil --fork-url $FORK_RPC_URL --fork-block-number $FORK_BLOCK_NUMBER --chain-id 31337",
+    "unlink-contracts": "rm -rf ./node_modules/@zoralabs/protocol-rewards && cp -r ../protocol-rewards ./node_modules/@zoralabs/protocol-rewards",
+    "link-contracts": "rm -rf ./node_modules && cd .. && yarn"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
Symlink doesnt work with verification with foundry, so this is a hack that allows you to unlink the symlink before deploying, then re-link it after
