### PR TITLE
Included all errors in erc1155 and preminter abis

### DIFF
--- a/.changeset/soft-hats-travel.md
+++ b/.changeset/soft-hats-travel.md
@@ -1,0 +1,5 @@
+---
+"@zoralabs/zora-1155-contracts": patch
+---
+
+Include all minter and royalty errors in erc1155 and premint executor abis

--- a/packages/1155-contracts/src/interfaces/ICreatorRoyaltiesControl.sol
+++ b/packages/1155-contracts/src/interfaces/ICreatorRoyaltiesControl.sol
@@ -3,6 +3,11 @@ pragma solidity 0.8.17;
 
 import {IERC2981} from "@openzeppelin/contracts/interfaces/IERC2981.sol";
 
+interface ICreatorRoyaltyErrors {
+    /// @notice Thrown when a user tries to have 100% supply royalties
+    error InvalidMintSchedule();
+}
+
 interface ICreatorRoyaltiesControl is IERC2981 {
     /// @notice The RoyaltyConfiguration struct is used to store the royalty configuration for a given token.
     /// @param royaltyMintSchedule Every nth token will go to the royalty recipient.
@@ -13,9 +18,6 @@ interface ICreatorRoyaltiesControl is IERC2981 {
         uint32 royaltyBPS;
         address royaltyRecipient;
     }
-
-    /// @notice Thrown when a user tries to have 100% supply royalties
-    error InvalidMintSchedule();
 
     /// @notice Event emitted when royalties are updated
     event UpdatedRoyalties(uint256 indexed tokenId, address indexed user, RoyaltyConfiguration configuration);

--- a/packages/1155-contracts/src/interfaces/ILimitedMintPerAddress.sol
+++ b/packages/1155-contracts/src/interfaces/ILimitedMintPerAddress.sol
@@ -3,8 +3,10 @@ pragma solidity 0.8.17;
 
 import {IERC165Upgradeable} from "@zoralabs/openzeppelin-contracts-upgradeable/contracts/interfaces/IERC165Upgradeable.sol";
 
-interface ILimitedMintPerAddress is IERC165Upgradeable {
+interface ILimitedMintPerAddressErrors {
     error UserExceedsMintLimit(address user, uint256 limit, uint256 requestedAmount);
+}
 
+interface ILimitedMintPerAddress is IERC165Upgradeable, ILimitedMintPerAddressErrors {
     function getMintedPerWallet(address token, uint256 tokenId, address wallet) external view returns (uint256);
 }

--- a/packages/1155-contracts/src/interfaces/IMinterErrors.sol
+++ b/packages/1155-contracts/src/interfaces/IMinterErrors.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IMinterErrors {
+    error CallerNotZoraCreator1155();
+    error MinterContractAlreadyExists();
+    error MinterContractDoesNotExist();
+
+    error SaleEnded();
+    error SaleHasNotStarted();
+    error WrongValueSent();
+    error InvalidMerkleProof(address mintTo, bytes32[] merkleProof, bytes32 merkleRoot);
+}

--- a/packages/1155-contracts/src/interfaces/IZoraCreator1155Errors.sol
+++ b/packages/1155-contracts/src/interfaces/IZoraCreator1155Errors.sol
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-interface IZoraCreator1155Errors {
+import {ICreatorRoyaltyErrors} from "./ICreatorRoyaltiesControl.sol";
+import {ILimitedMintPerAddressErrors} from "./ILimitedMintPerAddress.sol";
+import {IMinterErrors} from "./IMinterErrors.sol";
+
+interface IZoraCreator1155Errors is ICreatorRoyaltyErrors, ILimitedMintPerAddressErrors, IMinterErrors {
     error Call_TokenIdMismatch();
     error TokenIdMismatch(uint256 expected, uint256 actual);
     error UserMissingRoleForToken(address user, uint256 tokenId, uint256 role);

--- a/packages/1155-contracts/src/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.sol
+++ b/packages/1155-contracts/src/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.sol
@@ -7,6 +7,7 @@ import {ICreatorCommands} from "../../interfaces/ICreatorCommands.sol";
 import {SaleStrategy} from "../SaleStrategy.sol";
 import {SaleCommandHelper} from "../utils/SaleCommandHelper.sol";
 import {LimitedMintPerAddress} from "../utils/LimitedMintPerAddress.sol";
+import {IMinterErrors} from "../../interfaces/IMinterErrors.sol";
 
 /*
 
@@ -36,7 +37,7 @@ import {LimitedMintPerAddress} from "../utils/LimitedMintPerAddress.sol";
 /// @title ZoraCreatorFixedPriceSaleStrategy
 /// @notice A sale strategy for ZoraCreator that allows for fixed price sales over a given time period
 /// @author @iainnash / @tbtstl
-contract ZoraCreatorFixedPriceSaleStrategy is Enjoy, SaleStrategy, LimitedMintPerAddress {
+contract ZoraCreatorFixedPriceSaleStrategy is Enjoy, SaleStrategy, LimitedMintPerAddress, IMinterErrors {
     struct SalesConfig {
         /// @notice Unix timestamp for the sale start
         uint64 saleStart;
@@ -68,10 +69,6 @@ contract ZoraCreatorFixedPriceSaleStrategy is Enjoy, SaleStrategy, LimitedMintPe
     function contractVersion() external pure override returns (string memory) {
         return "1.1.0";
     }
-
-    error WrongValueSent();
-    error SaleEnded();
-    error SaleHasNotStarted();
 
     event SaleSet(address indexed mediaContract, uint256 indexed tokenId, SalesConfig salesConfig);
     event MintComment(address indexed sender, address indexed tokenContract, uint256 indexed tokenId, uint256 quantity, string comment);

--- a/packages/1155-contracts/src/minters/merkle/ZoraCreatorMerkleMinterStrategy.sol
+++ b/packages/1155-contracts/src/minters/merkle/ZoraCreatorMerkleMinterStrategy.sol
@@ -9,6 +9,7 @@ import {SaleStrategy} from "../SaleStrategy.sol";
 import {ICreatorCommands} from "../../interfaces/ICreatorCommands.sol";
 import {SaleCommandHelper} from "../utils/SaleCommandHelper.sol";
 import {LimitedMintPerAddress} from "../utils/LimitedMintPerAddress.sol";
+import {IMinterErrors} from "../../interfaces/IMinterErrors.sol";
 
 /*
 
@@ -38,7 +39,7 @@ import {LimitedMintPerAddress} from "../utils/LimitedMintPerAddress.sol";
 /// @title ZoraCreatorMerkleMinterStrategy
 /// @notice Mints tokens based on a merkle tree, for presales for example
 /// @author @iainnash / @tbtstl
-contract ZoraCreatorMerkleMinterStrategy is Enjoy, SaleStrategy, LimitedMintPerAddress {
+contract ZoraCreatorMerkleMinterStrategy is Enjoy, SaleStrategy, LimitedMintPerAddress, IMinterErrors {
     using SaleCommandHelper for ICreatorCommands.CommandSet;
 
     /// @notice General merkle sale settings
@@ -58,12 +59,6 @@ contract ZoraCreatorMerkleMinterStrategy is Enjoy, SaleStrategy, LimitedMintPerA
 
     /// @notice Storage for allowed merkle settings for the sales configuration
     mapping(address => mapping(uint256 => MerkleSaleSettings)) public allowedMerkles;
-    // target -> tokenId -> settings
-
-    error SaleEnded();
-    error SaleHasNotStarted();
-    error WrongValueSent();
-    error InvalidMerkleProof(address mintTo, bytes32[] merkleProof, bytes32 merkleRoot);
 
     /// @notice ContractURI for contract information with the strategy
     function contractURI() external pure override returns (string memory) {

--- a/packages/1155-contracts/src/minters/redeem/ZoraCreatorRedeemMinterFactory.sol
+++ b/packages/1155-contracts/src/minters/redeem/ZoraCreatorRedeemMinterFactory.sol
@@ -12,6 +12,7 @@ import {ICreatorCommands} from "../../interfaces/ICreatorCommands.sol";
 import {ZoraCreatorRedeemMinterStrategy} from "./ZoraCreatorRedeemMinterStrategy.sol";
 import {IZoraCreator1155} from "../../interfaces/IZoraCreator1155.sol";
 import {SharedBaseConstants} from "../../shared/SharedBaseConstants.sol";
+import {IMinterErrors} from "../../interfaces/IMinterErrors.sol";
 
 /*
 
@@ -41,15 +42,11 @@ import {SharedBaseConstants} from "../../shared/SharedBaseConstants.sol";
 /// @title ZoraCreatorRedeemMinterFactory
 /// @notice A factory for ZoraCreatorRedeemMinterStrategy contracts
 /// @author @jgeary
-contract ZoraCreatorRedeemMinterFactory is Enjoy, IContractMetadata, SharedBaseConstants, IVersionedContract, IMinter1155 {
+contract ZoraCreatorRedeemMinterFactory is Enjoy, IContractMetadata, SharedBaseConstants, IVersionedContract, IMinter1155, IMinterErrors {
     bytes4 constant LEGACY_ZORA_IMINTER1155_INTERFACE_ID = 0x6467a6fc;
     address public immutable zoraRedeemMinterImplementation;
 
     event RedeemMinterDeployed(address indexed creatorContract, address indexed minterContract);
-
-    error CallerNotZoraCreator1155();
-    error MinterContractAlreadyExists();
-    error MinterContractDoesNotExist();
 
     constructor() {
         zoraRedeemMinterImplementation = address(new ZoraCreatorRedeemMinterStrategy());

--- a/packages/1155-contracts/src/royalties/CreatorRoyaltiesControl.sol
+++ b/packages/1155-contracts/src/royalties/CreatorRoyaltiesControl.sol
@@ -4,13 +4,14 @@ pragma solidity 0.8.17;
 import {CreatorRoyaltiesStorageV1} from "./CreatorRoyaltiesStorageV1.sol";
 import {ICreatorRoyaltiesControl} from "../interfaces/ICreatorRoyaltiesControl.sol";
 import {SharedBaseConstants} from "../shared/SharedBaseConstants.sol";
+import {ICreatorRoyaltyErrors} from "../interfaces/ICreatorRoyaltiesControl.sol";
 import {IERC2981} from "@openzeppelin/contracts/interfaces/IERC2981.sol";
 
 /// Imagine. Mint. Enjoy.
 /// @title CreatorRoyaltiesControl
 /// @author ZORA @iainnash / @tbtstl
 /// @notice Contract for managing the royalties of an 1155 contract
-abstract contract CreatorRoyaltiesControl is CreatorRoyaltiesStorageV1, SharedBaseConstants {
+abstract contract CreatorRoyaltiesControl is CreatorRoyaltiesStorageV1, SharedBaseConstants, ICreatorRoyaltyErrors {
     uint256 immutable ROYALTY_BPS_TO_PERCENT = 10_000;
 
     /// @notice The royalty information for a given token.

--- a/packages/1155-contracts/test/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.t.sol
+++ b/packages/1155-contracts/test/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.t.sol
@@ -9,7 +9,7 @@ import {IZoraCreator1155Errors} from "../../../src/interfaces/IZoraCreator1155Er
 import {IMinter1155} from "../../../src/interfaces/IMinter1155.sol";
 import {ICreatorRoyaltiesControl} from "../../../src/interfaces/ICreatorRoyaltiesControl.sol";
 import {IZoraCreator1155Factory} from "../../../src/interfaces/IZoraCreator1155Factory.sol";
-import {ILimitedMintPerAddress} from "../../../src/interfaces/ILimitedMintPerAddress.sol";
+import {ILimitedMintPerAddressErrors} from "../../../src/interfaces/ILimitedMintPerAddress.sol";
 import {ZoraCreatorFixedPriceSaleStrategy} from "../../../src/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.sol";
 
 contract ZoraCreatorFixedPriceSaleStrategyTest is Test {
@@ -279,7 +279,7 @@ contract ZoraCreatorFixedPriceSaleStrategyTest is Test {
         vm.deal(tokenRecipient, totalValue);
 
         vm.prank(tokenRecipient);
-        vm.expectRevert(abi.encodeWithSelector(ILimitedMintPerAddress.UserExceedsMintLimit.selector, tokenRecipient, 5, 6));
+        vm.expectRevert(abi.encodeWithSelector(ILimitedMintPerAddressErrors.UserExceedsMintLimit.selector, tokenRecipient, 5, 6));
         target.mint{value: totalValue}(fixedPrice, newTokenId, numTokens, abi.encode(tokenRecipient, ""));
     }
 

--- a/packages/1155-contracts/test/minters/merkle/ZoraCreatorMerkleMinterStrategy.t.sol
+++ b/packages/1155-contracts/test/minters/merkle/ZoraCreatorMerkleMinterStrategy.t.sol
@@ -8,7 +8,7 @@ import {Zora1155} from "../../../src/proxies/Zora1155.sol";
 import {IZoraCreator1155Errors} from "../../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IRenderer1155} from "../../../src/interfaces/IRenderer1155.sol";
 import {ICreatorRoyaltiesControl} from "../../../src/interfaces/ICreatorRoyaltiesControl.sol";
-import {ILimitedMintPerAddress} from "../../../src/interfaces/ILimitedMintPerAddress.sol";
+import {ILimitedMintPerAddressErrors} from "../../../src/interfaces/ILimitedMintPerAddress.sol";
 import {IZoraCreator1155Factory} from "../../../src/interfaces/IZoraCreator1155Factory.sol";
 import {ZoraCreatorMerkleMinterStrategy} from "../../../src/minters/merkle/ZoraCreatorMerkleMinterStrategy.sol";
 
@@ -290,7 +290,7 @@ contract ZoraCreatorMerkleMinterStrategyTest is Test {
 
         vm.deal(mintTo, 1.000777 ether);
 
-        vm.expectRevert(abi.encodeWithSelector(ILimitedMintPerAddress.UserExceedsMintLimit.selector, mintTo, 10, 11));
+        vm.expectRevert(abi.encodeWithSelector(ILimitedMintPerAddressErrors.UserExceedsMintLimit.selector, mintTo, 10, 11));
         target.mint{value: 1.000777 ether}(merkleMinter, newTokenId, 1, abi.encode(mintTo, maxQuantity, pricePerToken, merkleProof));
 
         vm.stopPrank();

--- a/packages/1155-contracts/test/premint/ZoraCreator1155PremintExecutor.t.sol
+++ b/packages/1155-contracts/test/premint/ZoraCreator1155PremintExecutor.t.sol
@@ -18,6 +18,7 @@ import {ZoraCreator1155PremintExecutorImpl} from "../../src/delegation/ZoraCreat
 import {ZoraCreator1155Attribution, ContractCreationConfig, TokenCreationConfig, PremintConfig} from "../../src/delegation/ZoraCreator1155Attribution.sol";
 import {UUPSUpgradeable} from "@zoralabs/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {ProxyShim} from "../../src/utils/ProxyShim.sol";
+import {IMinterErrors} from "../../src/interfaces/IMinterErrors.sol";
 
 contract ZoraCreator1155PreminterTest is Test {
     uint256 internal constant CONTRACT_BASE_ID = 0;
@@ -564,7 +565,7 @@ contract ZoraCreator1155PreminterTest is Test {
         // execute mint directly on the contract - and check make sure it reverts if minted after sale start
         IMinter1155 fixedPriceMinter = factory.defaultMinters()[0];
         if (shouldRevert) {
-            vm.expectRevert(ZoraCreatorFixedPriceSaleStrategy.SaleEnded.selector);
+            vm.expectRevert(IMinterErrors.SaleEnded.selector);
         }
 
         vm.deal(premintExecutor, mintCost);


### PR DESCRIPTION
Extract minter, royalty, and mint limit errors to interface and have IERC1155Errors inherit from that, enabling those errors to show up in both the erc1155 and premint executor abis