### PR TITLE
fix premint uid bug

### DIFF
--- a/.changeset/tame-chairs-obey.md
+++ b/.changeset/tame-chairs-obey.md
@@ -1,0 +1,5 @@
+---
+"@zoralabs/zora-1155-contracts": patch
+---
+
+Fixed setting uid when doing a premint v1

--- a/packages/1155-contracts/src/delegation/ZoraCreator1155Attribution.sol
+++ b/packages/1155-contracts/src/delegation/ZoraCreator1155Attribution.sol
@@ -457,6 +457,8 @@ library DelegatedTokenCreation {
     ) private view returns (DelegatedTokenSetup memory params, bytes[] memory tokenSetupActions) {
         validatePremint(premintConfig.tokenConfig.mintStart, premintConfig.deleted);
 
+        params.uid = premintConfig.uid;
+
         tokenSetupActions = PremintTokenSetup.makeSetupNewTokenCalls(nextTokenId, premintConfig.tokenConfig);
 
         params.tokenURI = premintConfig.tokenConfig.tokenURI;

--- a/packages/1155-contracts/test/premint/ZoraCreator1155PremintExecutor.t.sol
+++ b/packages/1155-contracts/test/premint/ZoraCreator1155PremintExecutor.t.sol
@@ -143,6 +143,7 @@ contract ZoraCreator1155PreminterTest is Test {
         IZoraCreator1155 created1155Contract = IZoraCreator1155(contractAddress);
         // get the created contract, and make sure that tokens have been minted to the address
         assertEq(created1155Contract.balanceOf(premintExecutor, tokenId), quantityToMint);
+        assertEq(ZoraCreator1155Impl(address(created1155Contract)).delegatedTokenId(premintConfig.uid), tokenId);
     }
 
     function test_successfullyMintsTokens() external {


### PR DESCRIPTION
Premint v1 was not storing the created token id for the uid.  this fixed that bug