### PR TITLE
fix: make IZoraCreator1155 interface ID static in tests

### DIFF
--- a/packages/1155-contracts/test/nft/ZoraCreator1155.t.sol
+++ b/packages/1155-contracts/test/nft/ZoraCreator1155.t.sol
@@ -1365,9 +1365,9 @@ contract ZoraCreator1155Test is Test {
     function test_supportsInterface() external {
         init();
 
-        // TODO: make this static
-        bytes4 interfaceId = type(IZoraCreator1155).interfaceId;
-        assertEq(target.supportsInterface(interfaceId), true);
+        // Interface ID for IZoraCreator1155
+        bytes4 constant IZORA_CREATOR_1155_INTERFACE_ID = 0x3a8ec461;
+        assertEq(target.supportsInterface(IZORA_CREATOR_1155_INTERFACE_ID), true);
 
         bytes4 erc1155InterfaceId = bytes4(0xd9b67a26);
         assertTrue(target.supportsInterface(erc1155InterfaceId));


### PR DESCRIPTION
Replace runtime interface ID computation with a static constant in ZoraCreator1155.t.sol.
This change improves test efficiency by using a pre-computed interface ID instead of
calculating it at runtime. The value 0x3a8ec461 is the correct interface ID for
IZoraCreator1155 based on ERC-165 specification.