### PR TITLE
Fix Contract Addresses Link in factories.mdx

### DIFF
--- a/docs/pages/contracts/factories.mdx
+++ b/docs/pages/contracts/factories.mdx
@@ -6,7 +6,7 @@ title: Factory Addresses
 
 The Zora factory proxy has been deployed at a deterministic address on all networks.
 
-[View all contract addresses here.](https://github.com/ourzora/zora-protocol/tree/main/packages/protocol-deployments/addresses)
+[View all contract addresses here.](https://github.com/ourzora/zora-protocol/tree/main/packages/protocol-deployments/)
 [1155 Factory Code](https://github.com/ourzora/zora-protocol/blob/main/packages/1155-contracts/src/factory/ZoraCreator1155FactoryImpl.sol)
 
 #### Zora (Chain Id: 7777777)


### PR DESCRIPTION
The previous link pointed to a non-existing subdirectory addresses.
The new link correctly directs to the protocol-deployments folder where contract deployment data is stored.

