### PR TITLE
 Fixing Typos and Grammar Issues in Documentation

### DIFF
--- a/docs/pages/changelogs/protocol-deployments.mdx
+++ b/docs/pages/changelogs/protocol-deployments.mdx
@@ -5,7 +5,7 @@
 
 ### Patch Changes
 
-- [70b039ce](https://github.com/ourzora/zora-protocol/commit/70b039ce): Deployed ZoraFactory for coins to determinisitic 7777777 addresses on base and base sepolia
+- [70b039ce](https://github.com/ourzora/zora-protocol/commit/70b039ce): Deployed ZoraFactory for coins to deterministic 7777777 addresses on base and base sepolia
 
 ## 0.5.2
 

--- a/docs/pages/contracts/Comments.mdx
+++ b/docs/pages/contracts/Comments.mdx
@@ -25,7 +25,7 @@ and the referrer address is specified as an argument when commenting or Sparking
 
 ## Building on comments and earning referral rewards
 
-Developers can integrate the Comments contract into on their platform from day one and earn referral rewards when users when users spark a comment on their platform. 
+Developers can integrate the Comments contract into their platform from day one and earn referral rewards when users when users spark a comment on their platform. 
 
 When a referral address is specified when minting or sparking, 20% of the total Spark value is paid out to the referrer.
 

--- a/docs/pages/contracts/Metadata.mdx
+++ b/docs/pages/contracts/Metadata.mdx
@@ -31,7 +31,7 @@ Token metadata has the following json schema:
 
 Note that the `image` field should be a mime type starting with `image/`, however, for best rendering support use `png`, `jpg`, or `gif` images. Be aware larger file sizes may have issues rendering but also can display artifacts. It is recommended to test your images first on [testnet](https://testnet.zora.co/) networks and verify the thumbnails and media work.
 
-The `content` field supports _any_ mime type as the base of the NFT and is optional but for strong rendering support please ensure the `animation_url` field is set with an valid mime type (valid file types are: `gltf, glb, webm, mp3, mp4, m4v, ogv, and ogg along with mp3, wav, oga, and .html`).
+The `content` field supports _any_ mime type as the base of the NFT and is optional but for strong rendering support please ensure the `animation_url` field is set with a valid mime type (valid file types are: `gltf, glb, webm, mp3, mp4, m4v, ogv, and ogg along with mp3, wav, oga, and .html`).
 
 Contract and token metadata should be pinned to IPFS using a preferred pinning service,
 and the url when set on a contract or token should be in an ipfs url format, like: `ipfs://{cid}`.

--- a/docs/pages/contracts/Minting1155.mdx
+++ b/docs/pages/contracts/Minting1155.mdx
@@ -18,7 +18,7 @@ You can read more about the Zora mint fee [here](https://support.zora.co/en/arti
 
 ## Mint Function with Rewards
 
-Referring a mint and passing it in as the `mintReferral` with give a reward to the person or platform that refers the mint.
+Referring a mint and passing it in as the `mintReferral` will give a reward to the person or platform that refers the mint.
 View the rewards section for more information.
 
 Purchase tokens given a minter contract and minter arguments

--- a/packages/protocol-deployments/CHANGELOG.md
+++ b/packages/protocol-deployments/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- 70b039ce: Deployed ZoraFactory for coins to determinisitic 7777777 addresses on base and base sepolia
+- 70b039ce: Deployed ZoraFactory for coins to deterministic 7777777 addresses on base and base sepolia
 
 ## 0.5.2
 


### PR DESCRIPTION
1. protocol-deployments.mdx
Fixed Typo:
determinisitic → deterministic
2. Comments.mdx
Removed Redundant Words:
"when users when users" → "when users"
Fixed Incorrect Preposition:
"into on their platform" → "into their platform"
3. Metadata.mdx
Grammar Fix:
"set with an valid mime type" → "set with a valid mime type"
4. Minting1155.mdx
Fixed Verb Form:
"with give" → "will give"
