### PR TITLE
Fix header overwrite in storage layout generation script

### DIFF
--- a/packages/1155-contracts/script/storage-check.sh
+++ b/packages/1155-contracts/script/storage-check.sh
@@ -10,9 +10,9 @@ generate() {
   fi
 
   echo "=======================" > "$file"
-  echo "👁👁 STORAGE LAYOUT snapshot 👁👁" >"$file"
+  echo "👁👁 STORAGE LAYOUT snapshot 👁👁" >> "$file"
   echo "=======================" >> "$file"
-# shellcheck disable=SC2068
+  # shellcheck disable=SC2068
   for contract in ${contracts[@]}
   do
     { echo -e "\n======================="; echo "➡ $contract" ; echo -e "=======================\n"; } >> "$file"


### PR DESCRIPTION
Changed the second echo command in the generate() function from using a single redirection (>) to append redirection (>>) so that the header isn't overwritten.

