### PR TITLE
Fix async file operations in copyEnvironmentRunFiles script

### DIFF
--- a/packages/1155-contracts/script/copy-deployed-contracts.ts
+++ b/packages/1155-contracts/script/copy-deployed-contracts.ts
@@ -11,6 +11,7 @@ type Deploy = {
   returns: { value: string }[];
   chain: number;
 };
+
 async function copyEnvironmentRunFiles() {
   const latestFiles = await glob(`broadcast/**/*run-latest.json`);
 
@@ -21,10 +22,9 @@ async function copyEnvironmentRunFiles() {
       const parsed = JSON.parse(await readFile(file, "utf-8")) as Deploy;
       const returns = parsed.returns[0]?.value || "{}";
 
-      // a recent version of forge added a bug where the returns value with some sort of url based encoding.
-      // the below code is a hack to fix this. It should be removed once forge is fixed.
-      // use string regex replace all to remove all instances of \\ from returns (this appeared in a weird version of forge)
-      // also opening and closing quotes that incorrectly appear before opening bracket:
+      // A recent version of forge added a bug where the returns value had URL-based encoding.
+      // The code below is a hack to fix this. It should be removed once forge is fixed.
+      // Remove all instances of '\' from returns and fix improperly placed quotes.
       const filtered = returns
         .replace(/\\/g, "")
         .replace('"{', "{")
@@ -36,67 +36,65 @@ async function copyEnvironmentRunFiles() {
         timestamp: parsed.timestamp,
         returns: parsedReturns,
       };
-    }),
+    })
   );
 
-  const groupedByChainId = allFileContents.reduce(
-    (acc: any, file: any) => {
-      const chainId = file.chainId!;
-      if (isNaN(Number(chainId))) return acc;
-
-      if (!acc[chainId]) {
-        acc[chainId] = [];
-      }
-      acc[chainId]!.push(file);
-      return acc;
-    },
-    {} as Record<string, Deploy[]>,
-  );
+  const groupedByChainId = allFileContents.reduce((acc: any, file: any) => {
+    const chainId = file.chainId;
+    if (isNaN(Number(chainId))) return acc;
+    if (!acc[chainId]) {
+      acc[chainId] = [];
+    }
+    acc[chainId].push(file);
+    return acc;
+  }, {} as Record<string, Deploy[]>);
 
   const withLatest = Object.entries(groupedByChainId).map(
-    ([chainId, files]: any) => {
+    ([chainId, files]) => {
       const latest = files.sort(
-        (a: any, b: any) => b.timestamp! - a.timestamp!,
+        (a, b) => b.timestamp - a.timestamp
       )[0];
-      return {
-        chainId,
-        latest,
-      };
-    },
+      return { chainId, latest };
+    }
   );
 
-  withLatest.forEach(async ({ chainId, latest }) => {
+  for (const { chainId, latest } of withLatest) {
     const filePath = `addresses/${chainId}.json`;
-
-    const fileResponse = await readFile(filePath);
-    if (fileResponse) {
-      const version = JSON.parse(fileResponse.toString("utf-8"));
-      if (
-        semverGt(
-          version.CONTRACT_1155_IMPL_VERSION,
-          latest!.returns.CONTRACT_1155_IMPL_VERSION,
-        )
-      ) {
-        console.log(
-          `skipping since ${version.CONTRACT_1155_IMPL_VERSION} is newer than deploy files (${latest!.returns.CONTRACT_1155_IMPL_VERSION})`,
-        );
-        return;
+    let shouldWrite = true;
+    try {
+      const fileResponse = await readFile(filePath);
+      if (fileResponse) {
+        const version = JSON.parse(fileResponse.toString("utf-8"));
+        if (
+          semverGt(
+            version.CONTRACT_1155_IMPL_VERSION,
+            latest.returns.CONTRACT_1155_IMPL_VERSION
+          )
+        ) {
+          console.log(
+            `skipping since ${version.CONTRACT_1155_IMPL_VERSION} is newer than deploy files (${latest.returns.CONTRACT_1155_IMPL_VERSION})`
+          );
+          shouldWrite = false;
+        }
       }
+    } catch (error) {
+      // File doesn't exist; we will write the file.
     }
-
-    await writeFile(
-      filePath,
-      JSON.stringify(
-        {
-          ...latest!.returns,
-          timestamp: latest!.timestamp,
-          commit: latest!.commit,
-        },
-        null,
-        2,
-      ),
-    );
-  });
+    if (shouldWrite) {
+      await writeFile(
+        filePath,
+        JSON.stringify(
+          {
+            ...latest.returns,
+            timestamp: latest.timestamp,
+            commit: latest.commit,
+          },
+          null,
+          2
+        )
+      );
+    }
+  }
 }
 
 if (esMain(import.meta)) {


### PR DESCRIPTION
Replaced the async forEach loop with a for...of loop to ensure all asynchronous file operations (read/write) are properly awaited. This update guarantees that the file writes complete before the script exits while preserving the existing functionality.

