### PR TITLE
Update outdated link to ERC-1155 minting documentation

### DIFF
--- a/docs/pages/contracts/ERC20Minter.mdx
+++ b/docs/pages/contracts/ERC20Minter.mdx
@@ -152,4 +152,4 @@ struct SalesConfig {
 }
 ```
 
-[Using the ERC20 Minter contract with the protocol sdk](https://ourzora.github.io/zora-protocol/protocol-sdk/mint-client#collecting-an-onchain-1155-token)
+[Using the ERC20 Minter contract with the protocol sdk](https://docs.zora.co/contracts/Minting1155)


### PR DESCRIPTION
Replaced an outdated and broken link with the correct working URL to the ERC-1155 minting documentation.