### PR TITLE
Fix: Add username in social link response

### DIFF
--- a/docs/pages/coins/sdk/queries/profile.mdx
+++ b/docs/pages/coins/sdk/queries/profile.mdx
@@ -93,12 +93,15 @@ type ProfileData = {
     };
     socialAccounts?: {        // Connected social accounts
       instagram?: {
+        username?: string;
         displayName?: string;
       };
       tiktok?: {
+        username?: string;
         displayName?: string;
       };
       twitter?: {
+        username?: string;
         displayName?: string;
       };
     };

--- a/docs/pages/coins/sdk/queries/profile.mdx
+++ b/docs/pages/coins/sdk/queries/profile.mdx
@@ -104,6 +104,10 @@ type ProfileData = {
         username?: string;
         displayName?: string;
       };
+      "farcaster": {
+        "username": "string";
+        "displayName": "string";
+      };
     };
     linkedWallets?: {         // Connected wallets
       edges?: Array<{

--- a/packages/coins-sdk/src/client/types.gen.ts
+++ b/packages/coins-sdk/src/client/types.gen.ts
@@ -1029,15 +1029,27 @@ export type GetProfileResponses = {
           /**
            * The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
            */
+          username?: string;
+          /**
+           * The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
+           */
           displayName?: string;
         };
         tiktok?: {
           /**
            * The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
            */
+          username?: string;
+          /**
+           * The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
+           */
           displayName?: string;
         };
         twitter?: {
+          /**
+           * The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
+           */
+          username?: string;
           /**
            * The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
            */

--- a/packages/coins-sdk/src/client/types.gen.ts
+++ b/packages/coins-sdk/src/client/types.gen.ts
@@ -1055,6 +1055,16 @@ export type GetProfileResponses = {
            */
           displayName?: string;
         };
+        farcaster?: {
+          /**
+           * The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
+           */
+          username?: string;
+          /**
+           * The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
+           */
+          displayName?: string; 
+        }
       };
       linkedWallets: {
         edges: Array<{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated the `socialAccounts` response to include a `username` field for each platform and added support for the `farcaster` platform.


## Motivation and Context

Needed to fetch actual `usernames` from Zora profiles for my app. The original response only had `displayName`, which isn’t usable for links or mentions. This update matches the Zora `/profile` API docs, which provide both `username` and `displayName`.

Update from:
``` json
{
  "socialAccounts": {
    "instagram": {
      "displayName": "string"
    },
    "tiktok": {
      "displayName": "string"
    },
    "twitter": {
      "displayName": "string"
    }
  }
}
```
to

``` json
{
  "socialAccounts": {
    "instagram": {
      "username": "string",
      "displayName": "string"
    },
    "tiktok": {
      "username": "string",
      "displayName": "string"
    },
    "twitter": {
      "username": "string",
      "displayName": "string"
    },
    "farcaster": {
      "username": "string",
      "displayName": "string"
    }
  }
}

```

## Does this change the ABI/API?

- [ ] This changes the ABI/API

<!-- If so, please describe how and what potential impact this may have -->

## What tests did you add/modify to account for these changes

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New module / feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I added a changeset to account for this change

## Reviewer Checklist:

- [x] My review includes a symposis of the changes and potential issues
- [x] The code style is enforced
- [x] There are no risky / concerning changes / additions to the PR

