### PR TITLE
Sign typed data using account object instead of account address for the tradecoin api

### DIFF
--- a/packages/coins-sdk/src/actions/tradeCoin.ts
+++ b/packages/coins-sdk/src/actions/tradeCoin.ts
@@ -177,7 +177,7 @@ export async function tradeCoin({
         primaryType: "PermitSingle",
         types: PERMIT_SINGLE_TYPES,
         message,
-        account: typeof account === "string" ? account : account.address,
+        account: typeof account === "string" ? account : account,
       });
       signatures.push({
         signature,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Signing with the account instead of the account address in the tradecoin api

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
I'm facing an issue where I cannot use my local signed account. I noticed that we sign using the account address instead of the authed account.
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this change the ABI/API?

- [ ] This changes the ABI/API

<!-- If so, please describe how and what potential impact this may have -->

## What tests did you add/modify to account for these changes

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New module / feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I added a changeset to account for this change

## Reviewer Checklist:

- [ ] My review includes a symposis of the changes and potential issues
- [ ] The code style is enforced
- [ ] There are no risky / concerning changes / additions to the PR

