### PR TITLE
Fix typos and grammar in documentation

### DIFF
--- a/docs/pages/coins/index.mdx
+++ b/docs/pages/coins/index.mdx
@@ -12,7 +12,7 @@ This is the first time creators earn across posts, creators, and the platform. *
 
 ## How It Works
 
-Every coin has a **backing currency** and trades through a dedicated Uniswap V4 pool that with a custom hook that:
+Every coin has a **backing currency** and trades through a dedicated Uniswap V4 pool with a custom hook that:
 - **Distributes rewards** to creators, referrers, and the protocol on every trade
 - **Preserves liquidity** by locking 33% of trading fees as permanent pool depth
 - **Converts fees** through multi-hop swaps to ensure all rewards are paid in ZORA

--- a/docs/pages/coins/sdk/metadata-builder.md
+++ b/docs/pages/coins/sdk/metadata-builder.md
@@ -2,9 +2,9 @@
 
 The ZORA SDK supports handling metadata when using an SDK API key.
 
-This utilizes ZORA's internal IPFS pinning and delivery infastructure.
+This utilizes ZORA's internal IPFS pinning and delivery infrastructure.
 
-You are welcome to implement your own uploader or connect another IPFS provider to the uploader infastructure. You'll get performant uploads and more reliable metadata indexing using this service. You also can utilize a `multiUploader` interface to upload to both your own service and ZORA's service.
+You are welcome to implement your own uploader or connect another IPFS provider to the uploader infrastructure. You'll get performant uploads and more reliable metadata indexing using this service. You also can utilize a `multiUploader` interface to upload to both your own service and ZORA's service.
 
 ## Example Usage
 


### PR DESCRIPTION
Fixed documentation issues:

1. **metadata-builder.md**: Fixed "infastructure" → "infrastructure" (2 occurrences)
2. **coins/index.mdx**: Fixed grammar error "pool that with a custom hook" → "pool with a custom hook"

These are simple text corrections to improve documentation quality.