### PR TITLE
fix createcoin wrong factory address comparison

### DIFF
--- a/packages/coins-sdk/src/actions/createCoin.ts
+++ b/packages/coins-sdk/src/actions/createCoin.ts
@@ -175,7 +175,10 @@ export async function createCoin({
 
   // Sanity check that the call is for the correct factory contract
   if (!isAddressEqual(createContentCall.to, coinFactoryAddressForChain)) {
-    throw new Error("Creator coin is not supported for this SDK version");
+    const extractedFactoryAddress = '0x' + createContentCall.data.substring(34, 74);
+    if (!isAddressEqual(extractedFactoryAddress as Address, coinFactoryAddressForChain)) {
+      throw new Error("Creator coin is not supported for this SDK version");
+    }
   }
 
   // Sanity check to ensure no buy orders are sent with there parameters


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix broken calls to `createCoin`. 
- The old code was throwing on factory address check. 
- Now it fallbacks to extract the address from the first parameter of the calldata (expecting an `execute` function) and check this extracted address against the hardcoded factory address. 
- It is done inside a nested conditional to keep the old code and maintain backwards compatibility. (I don't know if this is a need, may be better to just replace once check with the other?!)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, the `createCoin` function throws:
```
Error: Creator coin is not supported for this SDK version
```
even when the transaction is a valid `execute` call to a valid factory address.

## Does this change the ABI/API?

- [ ] This changes the ABI/API

<!-- If so, please describe how and what potential impact this may have -->

## What tests did you add/modify to account for these changes

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Patched and tested locally, deployed to production with patch-package on a different private project. Seems to be working fine again.

This package is building locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New module / feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I added a changeset to account for this change

## Reviewer Checklist:

- [ ] My review includes a symposis of the changes and potential issues
- [ ] The code style is enforced
- [ ] There are no risky / concerning changes / additions to the PR

