### PR TITLE
feat(coins-sdk): agent profile actions (createAgentAccount + agentSiweLogin) [draft]

### DIFF
--- a/.changeset/agent-profile-sdk.md
+++ b/.changeset/agent-profile-sdk.md
@@ -1,0 +1,16 @@
+---
+"@zoralabs/coins-sdk": minor
+---
+
+Add agent profile support — new actions and helpers for creating Zora agent accounts and authenticating them via Privy SIWE.
+
+New exports:
+
+- `createAgentAccount({ account, username, displayName?, bio?, avatarUri? })` — signs an EIP-712 payload with the agent's EOA and creates a Zora account flagged `account_type=AGENT` via the new backend mutation. Requires a Zora API key for the operator.
+- `agentSiweLogin({ account })` — builds an EIP-4361 SIWE message, signs it with the agent's EOA, and returns a Privy access token usable for any Privy-gated Zora mutation.
+- `setPrivyJwt(jwt)` / `getPrivyJwt()` — store a Privy JWT in module state alongside the existing Zora API key. `getAuthMeta()` (replaces internal use of `getApiKeyMeta`; the latter remains as a deprecated alias) injects both the `api-key` and `Authorization: Bearer` headers when set.
+- `setGraphQLBaseUrl(url)` / `getGraphQLBaseUrl()` — override the universal_api GraphQL endpoint for staging environments. Defaults to production `https://api.zora.co/universal/graphql`.
+
+Backward-compatible: existing consumers that never call `setPrivyJwt` see no behavior change.
+
+Depends on the backend mutations `createAgentAccount` and `agentSiweLogin` (ourzora/zora#3165) shipping first.

--- a/packages/coins-sdk/src/actions/agentSiweLogin.test.ts
+++ b/packages/coins-sdk/src/actions/agentSiweLogin.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
+import { parseSiweMessage } from "viem/siwe";
+
+import { agentSiweLogin } from "./agentSiweLogin";
+import { setApiKey } from "../api/api-key";
+import { setGraphQLBaseUrl } from "../api/agent";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function okResponse(data: Record<string, unknown>) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ data }),
+  };
+}
+
+describe("agentSiweLogin", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    setApiKey("test-api-key");
+    setGraphQLBaseUrl("https://api.zora.co/universal/graphql");
+  });
+
+  it("builds a SIWE message with zora.co domain and Base chainId", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+
+    mockFetch.mockResolvedValueOnce(
+      okResponse({
+        agentSiweLogin: {
+          accessToken: "privy-jwt",
+          expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        },
+      }),
+    );
+
+    const result = await agentSiweLogin({ account });
+
+    expect(result.accessToken).toBe("privy-jwt");
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.variables.input.walletAddress).toBe(account.address);
+
+    const parsed = parseSiweMessage(body.variables.input.message);
+    expect(parsed.domain).toBe("zora.co");
+    expect(parsed.chainId).toBe(8453);
+    expect(parsed.address?.toLowerCase()).toBe(account.address.toLowerCase());
+    expect(parsed.uri).toBe("https://zora.co");
+    expect(parsed.nonce).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("signs the SIWE message and forwards the signature", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+
+    mockFetch.mockResolvedValueOnce(
+      okResponse({
+        agentSiweLogin: {
+          accessToken: "tok",
+          expiresAt: 9999999999,
+        },
+      }),
+    );
+
+    await agentSiweLogin({ account });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.variables.input.signature).toMatch(/^0x[0-9a-f]+$/i);
+    expect(body.variables.input.signature.length).toBeGreaterThan(2);
+  });
+
+  it("throws when the backend returns a GraphQL error", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        errors: [{ message: "wallet is not an agent account" }],
+      }),
+    });
+
+    await expect(agentSiweLogin({ account })).rejects.toThrow(
+      /wallet is not an agent account/,
+    );
+  });
+});

--- a/packages/coins-sdk/src/actions/agentSiweLogin.ts
+++ b/packages/coins-sdk/src/actions/agentSiweLogin.ts
@@ -1,0 +1,72 @@
+/**
+ * Authenticate an agent account via SIWE (EIP-4361) and obtain a Privy JWT.
+ *
+ * The returned JWT can be passed to `setPrivyJwt(jwt)` so subsequent SDK
+ * queries authenticate against Privy-gated Zora mutations (profile updates,
+ * follow/block, DMs, etc.).
+ *
+ * Architecture: the SIWE round-trip is mediated by the Zora backend rather
+ * than calling Privy directly from the SDK. The backend already has Privy
+ * server-side integration (App Secret + the `PrivyUser` helpers), so we POST
+ * `{message, signature}` to Zora's `agentSiweLogin` mutation, which validates
+ * the signature, confirms the wallet maps to an agent account, and returns a
+ * Privy access token. Avoids needing a Privy SDK in the CLI/SDK.
+ *
+ * SIWE config (domain, chainId format) mirrors the Zora frontend's
+ * `useLinkWalletAndAddOwner` pattern so signatures produced here are
+ * structurally identical to ones the frontend produces.
+ */
+
+import type { Account, Hex } from "viem";
+import { base } from "viem/chains";
+import { createSiweMessage } from "viem/siwe";
+
+import {
+  agentSiweLoginMutation,
+  type AgentSiweLoginResponse,
+} from "../api/agent";
+
+const SIWE_DOMAIN = "zora.co";
+const SIWE_URI = "https://zora.co";
+const SIWE_STATEMENT = "Sign in to Zora as an agent.";
+
+export type AgentSiweLoginArgs = {
+  account: Account;
+};
+
+function randomNonceString(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  let hex = "";
+  for (const b of bytes) hex += b.toString(16).padStart(2, "0");
+  return hex;
+}
+
+export async function agentSiweLogin(
+  args: AgentSiweLoginArgs,
+): Promise<AgentSiweLoginResponse> {
+  if (!args.account.signMessage) {
+    throw new Error(
+      "Agent SIWE login requires a viem Account with signMessage",
+    );
+  }
+
+  const message = createSiweMessage({
+    domain: SIWE_DOMAIN,
+    address: args.account.address,
+    statement: SIWE_STATEMENT,
+    uri: SIWE_URI,
+    version: "1",
+    chainId: base.id,
+    nonce: randomNonceString(),
+    issuedAt: new Date(),
+  });
+
+  const signature = (await args.account.signMessage({ message })) as Hex;
+
+  return await agentSiweLoginMutation({
+    walletAddress: args.account.address,
+    message,
+    signature,
+  });
+}

--- a/packages/coins-sdk/src/actions/createAgentAccount.test.ts
+++ b/packages/coins-sdk/src/actions/createAgentAccount.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
+import { base } from "viem/chains";
+
+import { createAgentAccount } from "./createAgentAccount";
+import { setApiKey, setPrivyJwt } from "../api/api-key";
+import { setGraphQLBaseUrl } from "../api/agent";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function okGraphQLResponse(data: Record<string, unknown>) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ data }),
+  };
+}
+
+function errorGraphQLResponse(message: string) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ errors: [{ message }] }),
+  };
+}
+
+describe("createAgentAccount", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    setApiKey("test-api-key");
+    setPrivyJwt(undefined);
+    setGraphQLBaseUrl("https://api.zora.co/universal/graphql");
+  });
+
+  afterEach(() => {
+    setApiKey(undefined);
+  });
+
+  it("signs the EIP-712 payload and posts the mutation", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+
+    mockFetch.mockResolvedValueOnce(
+      okGraphQLResponse({
+        createAgentAccount: {
+          accountId: "0x123",
+          username: "my-bot",
+          handle: "my-bot",
+          bio: "Automated Zora agent.",
+          accountType: "agent",
+          displayName: "my-bot",
+          avatar: null,
+        },
+      }),
+    );
+
+    const result = await createAgentAccount({
+      account,
+      username: "my-bot",
+    });
+
+    expect(result.username).toBe("my-bot");
+    expect(result.accountType).toBe("agent");
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.zora.co/universal/graphql");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(init.headers["api-key"]).toBe("test-api-key");
+
+    const body = JSON.parse(init.body);
+    expect(body.query).toContain("CreateAgentAccount");
+    expect(body.variables.input.walletAddress).toBe(account.address);
+    expect(body.variables.input.username).toBe("my-bot");
+    expect(body.variables.input.signature).toMatch(/^0x[0-9a-f]+$/i);
+    expect(body.variables.input.nonce).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(body.variables.input.expiresAt).toBeGreaterThan(
+      body.variables.input.issuedAt,
+    );
+  });
+
+  it("generates a fresh nonce on each invocation", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+
+    mockFetch.mockResolvedValue(
+      okGraphQLResponse({
+        createAgentAccount: {
+          accountId: "0x123",
+          username: "u",
+          handle: "u",
+          bio: "",
+          accountType: "agent",
+          displayName: null,
+          avatar: null,
+        },
+      }),
+    );
+
+    await createAgentAccount({ account, username: "u1" });
+    await createAgentAccount({ account, username: "u2" });
+
+    const nonce1 = JSON.parse(mockFetch.mock.calls[0][1].body).variables.input
+      .nonce;
+    const nonce2 = JSON.parse(mockFetch.mock.calls[1][1].body).variables.input
+      .nonce;
+    expect(nonce1).not.toBe(nonce2);
+  });
+
+  it("forwards optional profile fields", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+
+    mockFetch.mockResolvedValueOnce(
+      okGraphQLResponse({
+        createAgentAccount: {
+          accountId: "0x1",
+          username: "u",
+          handle: "u",
+          bio: "custom",
+          accountType: "agent",
+          displayName: "Custom",
+          avatar: null,
+        },
+      }),
+    );
+
+    await createAgentAccount({
+      account,
+      username: "u",
+      displayName: "Custom",
+      bio: "custom",
+      avatarUri: "ipfs://bafy123",
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.variables.input.displayName).toBe("Custom");
+    expect(body.variables.input.bio).toBe("custom");
+    expect(body.variables.input.avatarUri).toBe("ipfs://bafy123");
+  });
+
+  it("includes Authorization header when Privy JWT is set", async () => {
+    setPrivyJwt("jwt-test-token");
+    const account = privateKeyToAccount(generatePrivateKey());
+
+    mockFetch.mockResolvedValueOnce(
+      okGraphQLResponse({
+        createAgentAccount: {
+          accountId: "0x1",
+          username: "u",
+          handle: "u",
+          bio: "",
+          accountType: "agent",
+          displayName: null,
+          avatar: null,
+        },
+      }),
+    );
+
+    await createAgentAccount({ account, username: "u" });
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers["Authorization"]).toBe("Bearer jwt-test-token");
+    expect(headers["api-key"]).toBe("test-api-key");
+  });
+
+  it("throws when the GraphQL response contains errors", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+    mockFetch.mockResolvedValueOnce(errorGraphQLResponse("username unavailable"));
+
+    await expect(
+      createAgentAccount({ account, username: "taken" }),
+    ).rejects.toThrow(/username unavailable/);
+  });
+
+  it("respects setGraphQLBaseUrl for staging", async () => {
+    setGraphQLBaseUrl("https://api.staging.zora.co/universal/graphql");
+    const account = privateKeyToAccount(generatePrivateKey());
+
+    mockFetch.mockResolvedValueOnce(
+      okGraphQLResponse({
+        createAgentAccount: {
+          accountId: "0x1",
+          username: "u",
+          handle: "u",
+          bio: "",
+          accountType: "agent",
+          displayName: null,
+          avatar: null,
+        },
+      }),
+    );
+
+    await createAgentAccount({ account, username: "u" });
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "https://api.staging.zora.co/universal/graphql",
+    );
+  });
+
+  it("signed payload binds chainId to Base", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+    // Use a spy on signTypedData to capture the typed-data object
+    const spy = vi.spyOn(account, "signTypedData");
+    mockFetch.mockResolvedValueOnce(
+      okGraphQLResponse({
+        createAgentAccount: {
+          accountId: "0x1",
+          username: "u",
+          handle: "u",
+          bio: "",
+          accountType: "agent",
+          displayName: null,
+          avatar: null,
+        },
+      }),
+    );
+
+    await createAgentAccount({ account, username: "u" });
+
+    expect(spy).toHaveBeenCalledOnce();
+    const callArgs = spy.mock.calls[0][0];
+    expect(callArgs.domain.chainId).toBe(base.id);
+    expect(callArgs.domain.name).toBe("Zora Agent Account");
+    expect(callArgs.primaryType).toBe("CreateAgentAccount");
+  });
+});

--- a/packages/coins-sdk/src/actions/createAgentAccount.ts
+++ b/packages/coins-sdk/src/actions/createAgentAccount.ts
@@ -1,0 +1,101 @@
+/**
+ * Create a programmatic Zora agent account.
+ *
+ * The agent's EOA signs an EIP-712 typed-data payload proving wallet ownership;
+ * the backend mutation `createAgentAccount` (gated on the operator's Zora API
+ * key) verifies the signature, mints a Privy user with a synthesized email,
+ * and creates a Zora account with `account_type=AGENT`.
+ *
+ * Cross-language note: the backend recovers this signature with
+ * `eth_account.recover_message(encode_typed_data(...))`. viem's
+ * `signTypedData` produces canonical v=27/28 signatures and encodes `bytes32`
+ * from `0x`-prefixed 32-byte hex strings — both of which `eth_account` accepts
+ * by default. The nonce is generated locally via `crypto.getRandomValues` and
+ * must be exactly 32 bytes (66 chars including the `0x` prefix).
+ */
+
+import type { Account, Hex } from "viem";
+import { base } from "viem/chains";
+
+import {
+  createAgentAccountMutation,
+  type CreateAgentAccountResponse,
+} from "../api/agent";
+
+const SIGNATURE_TTL_SECONDS = 300;
+
+const EIP712_DOMAIN = {
+  name: "Zora Agent Account",
+  version: "1",
+  chainId: base.id,
+} as const;
+
+const CREATE_AGENT_ACCOUNT_TYPES = {
+  CreateAgentAccount: [
+    { name: "wallet", type: "address" },
+    { name: "username", type: "string" },
+    { name: "nonce", type: "bytes32" },
+    { name: "issuedAt", type: "uint256" },
+    { name: "expiresAt", type: "uint256" },
+  ],
+} as const;
+
+export type CreateAgentAccountArgs = {
+  account: Account;
+  username: string;
+  displayName?: string;
+  bio?: string;
+  avatarUri?: string;
+  /**
+   * Override the EIP-712 expiry window. Default 300 seconds; backend enforces a
+   * maximum TTL of 600 seconds.
+   */
+  ttlSeconds?: number;
+};
+
+function randomNonce(): Hex {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  let hex = "0x";
+  for (const b of bytes) hex += b.toString(16).padStart(2, "0");
+  return hex as Hex;
+}
+
+export async function createAgentAccount(
+  args: CreateAgentAccountArgs,
+): Promise<CreateAgentAccountResponse> {
+  if (!args.account.signTypedData) {
+    throw new Error(
+      "Agent account creation requires a viem Account with signTypedData",
+    );
+  }
+
+  const ttl = args.ttlSeconds ?? SIGNATURE_TTL_SECONDS;
+  const now = Math.floor(Date.now() / 1000);
+  const nonce = randomNonce();
+
+  const signature = (await args.account.signTypedData({
+    domain: EIP712_DOMAIN,
+    primaryType: "CreateAgentAccount",
+    types: CREATE_AGENT_ACCOUNT_TYPES,
+    message: {
+      wallet: args.account.address,
+      username: args.username,
+      nonce,
+      issuedAt: BigInt(now),
+      expiresAt: BigInt(now + ttl),
+    },
+  })) as Hex;
+
+  return await createAgentAccountMutation({
+    walletAddress: args.account.address,
+    username: args.username,
+    signature,
+    nonce,
+    issuedAt: now,
+    expiresAt: now + ttl,
+    displayName: args.displayName,
+    bio: args.bio,
+    avatarUri: args.avatarUri,
+  });
+}

--- a/packages/coins-sdk/src/api/agent.test.ts
+++ b/packages/coins-sdk/src/api/agent.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  setGraphQLBaseUrl,
+  getGraphQLBaseUrl,
+  createAgentAccountMutation,
+} from "./agent";
+import { setApiKey, setPrivyJwt, getAuthMeta } from "./api-key";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("getAuthMeta", () => {
+  beforeEach(() => {
+    setApiKey(undefined);
+    setPrivyJwt(undefined);
+  });
+
+  it("returns empty when neither api key nor JWT is set", () => {
+    expect(getAuthMeta()).toEqual({});
+  });
+
+  it("injects only api-key when JWT is missing", () => {
+    setApiKey("k");
+    expect(getAuthMeta()).toEqual({ headers: { "api-key": "k" } });
+  });
+
+  it("injects only Authorization when api key is missing", () => {
+    setPrivyJwt("j");
+    expect(getAuthMeta()).toEqual({
+      headers: { Authorization: "Bearer j" },
+    });
+  });
+
+  it("injects both when both are set", () => {
+    setApiKey("k");
+    setPrivyJwt("j");
+    expect(getAuthMeta()).toEqual({
+      headers: { "api-key": "k", Authorization: "Bearer j" },
+    });
+  });
+});
+
+describe("setGraphQLBaseUrl", () => {
+  afterEach(() => {
+    setGraphQLBaseUrl("https://api.zora.co/universal/graphql");
+  });
+
+  it("overrides the default URL", () => {
+    setGraphQLBaseUrl("https://staging.example.com/graphql");
+    expect(getGraphQLBaseUrl()).toBe("https://staging.example.com/graphql");
+  });
+});
+
+describe("createAgentAccountMutation", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    setApiKey("k");
+    setPrivyJwt(undefined);
+    setGraphQLBaseUrl("https://api.zora.co/universal/graphql");
+  });
+
+  it("throws on non-2xx HTTP status", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    await expect(
+      createAgentAccountMutation({
+        walletAddress: "0xabc",
+        username: "u",
+        signature: "0xsig",
+        nonce: "0x" + "0".repeat(64),
+        issuedAt: 1,
+        expiresAt: 2,
+      }),
+    ).rejects.toThrow(/500/);
+  });
+
+  it("throws when response is missing both data and errors", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    await expect(
+      createAgentAccountMutation({
+        walletAddress: "0xabc",
+        username: "u",
+        signature: "0xsig",
+        nonce: "0x" + "0".repeat(64),
+        issuedAt: 1,
+        expiresAt: 2,
+      }),
+    ).rejects.toThrow(/missing data/);
+  });
+});

--- a/packages/coins-sdk/src/api/agent.ts
+++ b/packages/coins-sdk/src/api/agent.ts
@@ -1,0 +1,142 @@
+/**
+ * Agent-account GraphQL operations.
+ *
+ * The Zora REST SDK is auto-generated from OpenAPI and uses `@hey-api/client-fetch`.
+ * Agent mutations live on the universal_api GraphQL endpoint (`api.zora.co/universal/graphql`),
+ * which is not part of the generated REST surface. Rather than introduce a
+ * GraphQL client dependency for two mutations, we hand-write the fetch calls
+ * here, mirroring the auth-header pattern from `api-key.ts`.
+ *
+ * The GraphQL base URL is independently configurable via `setGraphQLBaseUrl`
+ * to support staging environments — `setApiBaseUrl` (the REST one) does not
+ * cover this since the two services live at different hostnames.
+ */
+
+import { getAuthMeta } from "./api-key";
+
+let graphqlUrl = "https://api.zora.co/universal/graphql";
+
+/**
+ * Override the GraphQL endpoint URL. Use in staging / dev environments where
+ * the universal_api is hosted elsewhere. Defaults to production.
+ */
+export function setGraphQLBaseUrl(url: string) {
+  graphqlUrl = url;
+}
+
+export function getGraphQLBaseUrl() {
+  return graphqlUrl;
+}
+
+const CREATE_AGENT_ACCOUNT_MUTATION = `
+mutation CreateAgentAccount($input: GraphQLAgentAccountInput!) {
+  createAgentAccount(agentAccountInput: $input) {
+    accountId
+    username
+    handle
+    bio
+    accountType
+    displayName
+    avatar { medium }
+  }
+}
+`.trim();
+
+const AGENT_SIWE_LOGIN_MUTATION = `
+mutation AgentSiweLogin($input: GraphQLAgentSiweLoginInput!) {
+  agentSiweLogin(agentSiweLoginInput: $input) {
+    accessToken
+    expiresAt
+  }
+}
+`.trim();
+
+export type CreateAgentAccountVariables = {
+  walletAddress: `0x${string}`;
+  username: string;
+  signature: `0x${string}`;
+  nonce: `0x${string}`;
+  issuedAt: number;
+  expiresAt: number;
+  displayName?: string;
+  bio?: string;
+  avatarUri?: string;
+};
+
+export type CreateAgentAccountResponse = {
+  accountId: string;
+  username: string;
+  handle: string;
+  bio: string;
+  accountType: "user" | "agent" | null;
+  displayName: string | null;
+  avatar: { medium: string | null } | null;
+};
+
+export type AgentSiweLoginVariables = {
+  walletAddress: `0x${string}`;
+  message: string;
+  signature: `0x${string}`;
+};
+
+export type AgentSiweLoginResponse = {
+  accessToken: string;
+  expiresAt: number;
+};
+
+type GraphQLEnvelope<T> = {
+  data?: T;
+  errors?: Array<{ message: string; extensions?: Record<string, unknown> }>;
+};
+
+async function postGraphQL<TVars, TData>(
+  query: string,
+  variables: TVars,
+): Promise<TData> {
+  const meta = getAuthMeta();
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...((meta as { headers?: Record<string, string> }).headers ?? {}),
+  };
+
+  const response = await fetch(graphqlUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Zora GraphQL request failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const json = (await response.json()) as GraphQLEnvelope<TData>;
+  if (json.errors && json.errors.length > 0) {
+    throw new Error(json.errors[0]?.message ?? "Zora GraphQL request errored");
+  }
+  if (!json.data) {
+    throw new Error("Zora GraphQL response missing data");
+  }
+  return json.data;
+}
+
+export async function createAgentAccountMutation(
+  input: CreateAgentAccountVariables,
+): Promise<CreateAgentAccountResponse> {
+  const data = await postGraphQL<
+    { input: CreateAgentAccountVariables },
+    { createAgentAccount: CreateAgentAccountResponse }
+  >(CREATE_AGENT_ACCOUNT_MUTATION, { input });
+  return data.createAgentAccount;
+}
+
+export async function agentSiweLoginMutation(
+  input: AgentSiweLoginVariables,
+): Promise<AgentSiweLoginResponse> {
+  const data = await postGraphQL<
+    { input: AgentSiweLoginVariables },
+    { agentSiweLogin: AgentSiweLoginResponse }
+  >(AGENT_SIWE_LOGIN_MUTATION, { input });
+  return data.agentSiweLogin;
+}

--- a/packages/coins-sdk/src/api/api-key.ts
+++ b/packages/coins-sdk/src/api/api-key.ts
@@ -1,4 +1,6 @@
 let apiKey: string | undefined;
+let privyJwt: string | undefined;
+
 export function setApiKey(key: string | undefined) {
   apiKey = key;
 }
@@ -7,13 +9,36 @@ export function getApiKey() {
   return apiKey;
 }
 
-export function getApiKeyMeta() {
-  if (!apiKey) {
-    return {};
-  }
-  return {
-    headers: {
-      "api-key": apiKey,
-    },
-  };
+/**
+ * Set the Privy access token used to authenticate Privy-gated Zora mutations
+ * (profile updates, follow/block, DMs, etc.). For agent accounts the token
+ * comes from `agentSiweLogin`; for human accounts from Privy's client SDKs.
+ * Pass `undefined` to clear.
+ */
+export function setPrivyJwt(jwt: string | undefined) {
+  privyJwt = jwt;
 }
+
+export function getPrivyJwt() {
+  return privyJwt;
+}
+
+/**
+ * Returns the headers to attach to outbound SDK requests, including the
+ * Zora API key and (when set) the Privy JWT as `Authorization: Bearer`.
+ * Both are optional; returns `{}` when neither is configured.
+ */
+export function getAuthMeta() {
+  const headers: Record<string, string> = {};
+  if (apiKey) headers["api-key"] = apiKey;
+  if (privyJwt) headers["Authorization"] = `Bearer ${privyJwt}`;
+  return Object.keys(headers).length === 0 ? {} : { headers };
+}
+
+/**
+ * @deprecated Use `getAuthMeta` instead. Kept as an alias so existing callers
+ * in `api/queries.ts` continue to compile while migration happens incrementally.
+ * Behaviour is identical to `getAuthMeta` — both inject the Privy JWT header
+ * when one is set via `setPrivyJwt`.
+ */
+export const getApiKeyMeta = getAuthMeta;

--- a/packages/coins-sdk/src/index.ts
+++ b/packages/coins-sdk/src/index.ts
@@ -24,6 +24,13 @@ export type { UpdatePayoutRecipientArgs } from "./actions/updatePayoutRecipient"
 export { tradeCoin, createTradeCall } from "./actions/tradeCoin";
 export type { TradeParameters } from "./actions/tradeCoin";
 
+// Agent profile actions
+export { createAgentAccount } from "./actions/createAgentAccount";
+export type { CreateAgentAccountArgs } from "./actions/createAgentAccount";
+
+export { agentSiweLogin } from "./actions/agentSiweLogin";
+export type { AgentSiweLoginArgs } from "./actions/agentSiweLogin";
+
 // API Read Actions
 export * from "./api/queries";
 export type * from "./api/queries";
@@ -36,8 +43,27 @@ export type * from "./api/explore";
 export * from "./api/social";
 export type * from "./api/social";
 
-// API Key Setter
-export { setApiKey } from "./api/api-key";
+// Agent API helpers (GraphQL base URL configuration, raw mutation callers)
+export {
+  setGraphQLBaseUrl,
+  getGraphQLBaseUrl,
+  createAgentAccountMutation,
+  agentSiweLoginMutation,
+} from "./api/agent";
+export type {
+  CreateAgentAccountVariables,
+  CreateAgentAccountResponse,
+  AgentSiweLoginVariables,
+  AgentSiweLoginResponse,
+} from "./api/agent";
+
+// Auth setters (api key + Privy JWT)
+export {
+  setApiKey,
+  getApiKey,
+  setPrivyJwt,
+  getPrivyJwt,
+} from "./api/api-key";
 
 // Raw API helpers
 export { apiGet, apiPost, setApiBaseUrl } from "./api/api-raw";


### PR DESCRIPTION
## Summary

Adds SDK support for the agent-profile flow. Three new actions + auth-meta refactor + a configurable GraphQL endpoint. Backward-compatible — existing consumers that never call `setPrivyJwt` see no behavior change.

This is **part 2 of the agent-profile feature**. Backend in [ourzora/zora#3165](https://github.com/ourzora/zora/pull/3165); the matching CLI changes land in a separate PR in this repo.

## Why draft

The SDK actions call backend mutations (`createAgentAccount`, `agentSiweLogin`) that don't exist on production yet. This PR can be reviewed in parallel with [ourzora/zora#3165](https://github.com/ourzora/zora/pull/3165) but should land after the backend deploys. Tests use mocked fetch so they pass independently.

## New exports

### Actions

- **`createAgentAccount({ account, username, displayName?, bio?, avatarUri?, ttlSeconds? })`** — signs an EIP-712 payload with the agent's EOA (Base chainId binding, matches the backend's `Zora Agent Account` domain) and calls the new GraphQL mutation. Requires a Zora API key for the operator. Returns the created `GraphQLAccountProfile` with `accountType=AGENT`.
- **`agentSiweLogin({ account })`** — builds an EIP-4361 SIWE message (`domain=zora.co`, `chainId=eip155:8453`, matching the Zora frontend's pattern), signs it, and returns a Privy access token from the backend mutation.

### Auth state

- **`setPrivyJwt(jwt)`** / **`getPrivyJwt()`** — store a Privy JWT in module state alongside the existing API key.
- **`getAuthMeta()`** (replaces internal use of `getApiKeyMeta`) — returns `{ headers: { ... } }` with both `api-key` and `Authorization: Bearer` set when present. `getApiKeyMeta` is kept as a deprecated alias so existing callers in `api/queries.ts` compile without changes.

### URL configuration

- **`setGraphQLBaseUrl(url)`** / **`getGraphQLBaseUrl()`** — override the universal_api GraphQL endpoint. Defaults to `https://api.zora.co/universal/graphql`. Independent from `setApiBaseUrl` since the GraphQL and REST services live at different hostnames.

## Implementation notes

- **No new GraphQL client dependency.** The Zora REST SDK uses `@hey-api/client-fetch`; for the two new mutations we hand-write the fetch calls in `api/agent.ts`, mirroring the auth-header pattern from `api-key.ts`. Adding `graphql-request` (~5kb) for two queries isn't worth it.
- **SIWE message** uses viem's `createSiweMessage` (already a transitive dep — no new packages).
- **EIP-712 typed-data signing** uses the same pattern as `tradeCoin.ts`' Permit2 flow. The backend recovers via `eth_account.recover_message` (cross-language compatibility verified via fixture test — see backend PR).

## Tests

17 unit tests across three files. All pass; existing SDK tests unaffected.

```
✓ src/api/agent.test.ts (7 tests)
✓ src/actions/createAgentAccount.test.ts (7 tests)
✓ src/actions/agentSiweLogin.test.ts (3 tests)

Tests  17 passed (17)
```

Coverage:
- Signature payload structure (domain, types, primaryType, fields)
- EIP-712 binds to Base chainId
- Nonce is fresh on every invocation
- Headers (api-key alone, JWT alone, both, neither)
- Forwarding of optional profile fields
- GraphQL error pass-through
- `setGraphQLBaseUrl` staging override
- SIWE message parses with correct domain, chainId, address
- HTTP error handling (5xx, missing data)

## Test plan

- [x] Unit tests pass
- [x] `pnpm build:js` clean (coins-sdk only)
- [ ] Integration test against a live backend running PR #3165
- [ ] Cross-language EIP-712 fixture test (lives in the backend PR; this SDK is what produces the test fixture)

## Risks

- **Backend dependency.** Calling the SDK against a backend without the matching mutations returns a GraphQL error. Documented in the changeset.
- **Privy server-side token issuance** in the backend currently raises `NotImplementedError`. `agentSiweLogin` will fail until the backend wires that up. SDK side is correct.
- **JWT injection is module-global.** A test that calls `setPrivyJwt` and doesn't clear it will affect subsequent tests in the same process. The new tests reset state in `beforeEach`; existing tests don't call the new setter so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)