### PR TITLE
fix: add evm_version to fix local build issues

### DIFF
--- a/packages/coins/foundry.toml
+++ b/packages/coins/foundry.toml
@@ -2,6 +2,7 @@
 src = "src"
 test = "test"
 libs = ["node_modules"]
+evm_version = "cancun"
 via_ir = true
 optimizer = true
 solc_version = '0.8.28'

--- a/packages/limit-orders/foundry.toml
+++ b/packages/limit-orders/foundry.toml
@@ -2,6 +2,7 @@
 src = "src"
 test = "test"
 libs = ["node_modules"]
+evm_version = "cancun"
 via_ir = true
 optimizer = true
 solc_version = '0.8.28'


### PR DESCRIPTION
## Description

Sets the `evm_version` to `cancun` in the Foundry configuration for the `coins` and `limit-orders` packages.

## Motivation and Context

Explicitly targeting the Cancun EVM version ensures that both packages compile against the correct EVM feature set, including support for transient storage and other Cancun-specific opcodes. Without this setting, the compiler may default to an older EVM version, potentially missing optimizations or compatibility with deployed infrastructure.

## Does this change the ABI/API?

- [ ] This changes the ABI/API

## What tests did you add/modify to account for these changes

No new tests were added. Existing test suites for both packages should be run to confirm compatibility with the Cancun EVM target.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New module / feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I added a changeset to account for this change

## Reviewer Checklist:

- [ ] My review includes a symposis of the changes and potential issues
- [ ] The code style is enforced
- [ ] There are no risky / concerning changes / additions to the PR