### PR TITLE
feat(coins-sdk): add apiUrl helper to coins sdk to allow consumers to resolve full api endpoint urls (needed in cli to resolve a bundler rpc url)

### DIFF
--- a/packages/coins-sdk/src/api/api-raw.ts
+++ b/packages/coins-sdk/src/api/api-raw.ts
@@ -8,6 +8,10 @@ export const apiGet = (path: string, data?: Record<string, unknown>) =>
 export const apiPost = (path: string, data?: Record<string, unknown>) =>
   client.post({ url: path, body: data, ...getApiKeyMeta() });
 
+export const apiUrl = (path: string) => {
+  return `${client.getConfig().baseUrl}${path}`;
+};
+
 export const setApiBaseUrl = (baseUrl: string) => {
   client.setConfig(createConfig({ baseUrl }));
 };

--- a/packages/coins-sdk/src/index.ts
+++ b/packages/coins-sdk/src/index.ts
@@ -40,7 +40,7 @@ export type * from "./api/social";
 export { setApiKey } from "./api/api-key";
 
 // Raw API helpers
-export { apiGet, apiPost, setApiBaseUrl } from "./api/api-raw";
+export { apiGet, apiPost, apiUrl, setApiBaseUrl } from "./api/api-raw";
 
 // Metadata Validation Utils
 export * from "./metadata";


### PR DESCRIPTION
## Description

Adds a new `apiUrl` helper function to the coins-sdk that constructs a full URL by combining the configured `baseUrl` with a given path. This function is exported from the SDK's public API alongside the existing `apiGet`, `apiPost`, and `setApiBaseUrl` helpers.

This PR depends on a pending PR for `universal-api-public-api:` https://github.com/ourzora/universal-api-public-api/pull/123

## Motivation and Context

Consumers of the SDK sometimes need to construct a full URL for a given API path (e.g., for use in direct fetch calls or link generation) without making a request. Previously, there was no way to access the configured base URL to build such URLs.

## Does this change the ABI/API?

- [x] This changes the ABI/API

A new exported function `apiUrl` is added to the public API of the SDK. This is a non-breaking addition.

## What tests did you add/modify to account for these changes

No tests were added or modified as part of this change.

## Types of changes

- [x] New module / feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I added a changeset to account for this change

## Reviewer Checklist:

- [ ] My review includes a symposis of the changes and potential issues
- [ ] The code style is enforced
- [ ] There are no risky / concerning changes / additions to the PR