### PR TITLE
Sync: CLI docs (coin group, wallet connect, wallet modes)

### DIFF
--- a/cli-docs/docs/pages/commands/coin.mdx
+++ b/cli-docs/docs/pages/commands/coin.mdx
@@ -1,0 +1,196 @@
+# coin
+
+Create and manage coins (posts). Requires a [wallet](/commands/setup) and an [API key](/commands/auth). Coin operations deploy from your [smart wallet](/guides/wallet-modes) when one is configured, otherwise your EOA.
+
+```bash
+zora coin [command]
+```
+
+## Subcommands
+
+| Subcommand    | Description                                |
+| ------------- | ------------------------------------------ |
+| `coin create` | Create a coin from a post                  |
+| `coin edit`   | Edit a post's image and/or description     |
+| `coin hide`   | Hide a coin from your holdings and profile |
+| `coin unhide` | Unhide a previously hidden coin            |
+
+## coin create
+
+Create a coin from a post — upload an image plus name/symbol/description and deploy a content coin on Base. The image and metadata are uploaded to Zora's IPFS storage.
+
+```bash
+zora coin create [options]
+```
+
+Run without flags to be prompted for each field. In `--json` (non-interactive) mode, the required fields must be passed as flags — there are no prompts.
+
+### Options
+
+| Flag                    | Description                                                                                                                       |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `--name <name>`         | Coin name — required                                                                                                              |
+| `--symbol <symbol>`     | Coin symbol (ticker) — required (2–20 letters/numbers, no spaces or punctuation)                                                  |
+| `--image <path>`        | Path to a local image file to upload — required (`PNG`, `JPEG`, `JPG`, `GIF`, `SVG`)                                              |
+| `--description <text>`  | Coin description (optional)                                                                                                       |
+| `--currency <currency>` | Backing currency: `ZORA`, `ETH`, `CREATOR_COIN`, `CREATOR_COIN_OR_ZORA`. Prompts if omitted (defaults to `ZORA` in `--json` mode) |
+| `--yes`                 | Skip the confirmation prompt and create directly                                                                                  |
+| `--json`                | Machine-readable JSON output                                                                                                      |
+
+:::info
+Creating a coin spends real funds for gas. Fund your wallet first — see [wallet modes](/guides/wallet-modes). If a smart wallet user operation fails for insufficient gas, the error includes a suggested top-up amount.
+:::
+
+### Examples
+
+#### Interactive
+
+```bash
+npx @zoralabs/cli coin create
+```
+
+Prompts for name, symbol, description, image path, and currency, then shows a summary to confirm before deploying.
+
+#### Non-interactive for scripting
+
+```bash
+npx @zoralabs/cli coin create \
+  --name "my post" \
+  --symbol MYPOST \
+  --image ./post.png \
+  --currency ZORA \
+  --yes \
+  --json
+```
+
+#### JSON output
+
+```json
+{
+  "action": "create",
+  "name": "my post",
+  "symbol": "MYPOST",
+  "currency": "ZORA",
+  "address": "0x1234...",
+  "creator": "0xabcd...",
+  "walletType": "smart_wallet",
+  "tx": "0x789abc..."
+}
+```
+
+`address` is the new coin's contract address and `tx` is the deploy transaction. `walletType` is `smart_wallet` or `eoa` depending on which wallet deployed it.
+
+:::tip
+For the **first post during onboarding**, use [`agent create`](/commands/agent#agent-create) with `--caption` and `--image` instead — it renders your caption onto the image in the official Zora brand card before posting. `coin create` publishes the image as-is.
+:::
+
+## coin edit
+
+Edit an existing post's **image** and/or **description** (caption), keeping its name and ticker fixed. This mirrors the "Edit post" action in the Zora app: the new metadata is uploaded to IPFS and the coin's on-chain `contractURI` is pointed at it. Only the coin's creator can edit it.
+
+```bash
+zora coin edit <identifier> [options]
+```
+
+`<identifier>` is a coin address, or a creator/trend name. Pass `--image`, `--description`, or both — whatever is omitted is preserved. With neither flag, the command prompts for a new caption (pre-filled with the current one).
+
+### Options
+
+| Flag                   | Description                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| `--description <text>` | New description (caption)                                                     |
+| `--image <path>`       | Path to a new local image file to upload (`PNG`, `JPEG`, `JPG`, `GIF`, `SVG`) |
+| `--yes`                | Skip the confirmation prompt and edit directly                                |
+| `--json`               | Machine-readable JSON output                                                  |
+
+:::info
+The name and ticker can't be changed — the Zora app keeps them fixed for coins too. Editing updates the coin's metadata on-chain, so it spends gas. Requires an [API key](/commands/auth) (the updated metadata is re-uploaded to IPFS).
+:::
+
+### Examples
+
+#### Change the caption
+
+```bash
+npx @zoralabs/cli coin edit 0x23dd...dbaa --description "new caption" --json
+```
+
+#### Change the image
+
+```bash
+npx @zoralabs/cli coin edit 0x23dd...dbaa --image ./new.png --json
+```
+
+#### JSON output
+
+```json
+{
+  "action": "edit",
+  "coin": "0x23dd...dbaa",
+  "name": "My Post",
+  "symbol": "MYPOST",
+  "edited": ["image", "description"],
+  "tokenUri": "ipfs://bafy...",
+  "tx": "0x85a8...",
+  "walletType": "smart_wallet"
+}
+```
+
+`edited` lists which fields changed, `tokenUri` is the new metadata URI on IPFS, and `tx` is the on-chain update transaction.
+
+## coin hide
+
+Hide a coin (e.g. an unwanted airdrop or spam) from your holdings and profile across Zora. Hiding is a personal preference scoped to your account — it doesn't move or burn the coin, and there's no holding requirement, so any coin can be hidden. This applies the same hide as the Zora app's "Hide post" action.
+
+```bash
+zora coin hide <identifier> [options]
+```
+
+`<identifier>` is a coin address (preferred for spam that may not be indexed) or a creator/trend name.
+
+### Options
+
+| Flag           | Description                                             |
+| -------------- | ------------------------------------------------------- |
+| `--chain <id>` | Chain id the coin is on (default: `8453`, Base mainnet) |
+| `--json`       | Machine-readable JSON output                            |
+
+### Example
+
+```bash
+npx @zoralabs/cli coin hide 0x1fa8...81b6 --json
+```
+
+```json
+{
+  "action": "hide",
+  "coin": "0x1fa8...81b6",
+  "hidden": true,
+  "profileId": "your-profile-id"
+}
+```
+
+## coin unhide
+
+Reverse a previous hide, restoring the coin to your holdings and profile.
+
+```bash
+zora coin unhide <identifier> [options]
+```
+
+Takes the same `<identifier>` and `--chain` / `--json` options as [`coin hide`](#coin-hide).
+
+### Example
+
+```bash
+npx @zoralabs/cli coin unhide 0x1fa8...81b6 --json
+```
+
+```json
+{
+  "action": "unhide",
+  "coin": "0x1fa8...81b6",
+  "hidden": false,
+  "profileId": "your-profile-id"
+}
+```

--- a/cli-docs/docs/pages/commands/create.mdx
+++ b/cli-docs/docs/pages/commands/create.mdx
@@ -1,68 +1,15 @@
 # create
 
-Create a coin from a post — upload an image plus name/symbol/description and deploy a content coin on Base. Requires a [wallet](/commands/setup) and an [API key](/commands/auth) (the image and metadata are uploaded to Zora's IPFS storage). Deploys from your [smart wallet](/guides/wallet-modes) when one is configured, otherwise your EOA.
-
-```bash
-zora create [options]
-```
-
-Run without flags to be prompted for each field. In `--json` (non-interactive) mode, the required fields must be passed as flags — there are no prompts.
-
-## Options
-
-| Flag                    | Description                                                                                                                       |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `--name <name>`         | Coin name — required                                                                                                              |
-| `--symbol <symbol>`     | Coin symbol (ticker) — required (2–20 letters/numbers, no spaces or punctuation)                                                  |
-| `--image <path>`        | Path to a local image file to upload — required (`PNG`, `JPEG`, `JPG`, `GIF`, `SVG`)                                              |
-| `--description <text>`  | Coin description (optional)                                                                                                       |
-| `--currency <currency>` | Backing currency: `ZORA`, `ETH`, `CREATOR_COIN`, `CREATOR_COIN_OR_ZORA`. Prompts if omitted (defaults to `ZORA` in `--json` mode) |
-| `--yes`                 | Skip the confirmation prompt and create directly                                                                                  |
-| `--json`                | Machine-readable JSON output                                                                                                      |
-
-:::info
-Creating a coin spends real funds for gas. Fund your wallet first — see [wallet modes](/guides/wallet-modes). If a smart wallet user operation fails for insufficient gas, the error includes a suggested top-up amount.
+:::warning
+The top-level `create` command is **deprecated** and will be removed in a future release. Use [`coin create`](/commands/coin#coin-create) instead. It still works identically for now.
 :::
 
-## Examples
-
-### Interactive
-
 ```bash
-npx @zoralabs/cli create
+# Old command
+zora create --name "my post" --symbol MYPOST --image ./post.png
+
+# Use this instead
+zora coin create --name "my post" --symbol MYPOST --image ./post.png
 ```
 
-Prompts for name, symbol, description, image path, and currency, then shows a summary to confirm before deploying.
-
-### Non-interactive for scripting
-
-```bash
-npx @zoralabs/cli create \
-  --name "my post" \
-  --symbol MYPOST \
-  --image ./post.png \
-  --currency ZORA \
-  --yes \
-  --json
-```
-
-### JSON output
-
-```json
-{
-  "action": "create",
-  "name": "my post",
-  "symbol": "MYPOST",
-  "currency": "ZORA",
-  "address": "0x1234...",
-  "creator": "0xabcd...",
-  "walletType": "smart_wallet",
-  "tx": "0x789abc..."
-}
-```
-
-`address` is the new coin's contract address and `tx` is the deploy transaction. `walletType` is `smart_wallet` or `eoa` depending on which wallet deployed it.
-
-:::tip
-For the **first post during onboarding**, use [`agent create`](/commands/agent#agent-create) with `--caption` and `--image` instead — it renders your caption onto the image in the official Zora brand card before posting. `create` publishes the image as-is.
-:::
+See the [`coin create`](/commands/coin#coin-create) documentation for full usage, options, and examples — along with the related [`coin edit`](/commands/coin#coin-edit), [`coin hide`](/commands/coin#coin-hide), and [`coin unhide`](/commands/coin#coin-unhide) commands.

--- a/cli-docs/docs/pages/commands/wallet.mdx
+++ b/cli-docs/docs/pages/commands/wallet.mdx
@@ -8,11 +8,12 @@ zora wallet [command]
 
 ## Subcommands
 
-| Subcommand         | Description                              |
-| ------------------ | ---------------------------------------- |
-| `wallet info`      | Show wallet address and storage location |
-| `wallet export`    | Print the raw private key to stdout      |
-| `wallet configure` | Create or import a wallet                |
+| Subcommand         | Description                                                        |
+| ------------------ | ------------------------------------------------------------------ |
+| `wallet info`      | Show wallet address and storage location                           |
+| `wallet export`    | Print the raw private key to stdout                                |
+| `wallet configure` | Create or import a wallet                                          |
+| `wallet connect`   | Connect an existing Zora account (auto-discovers its smart wallet) |
 
 ## Examples
 
@@ -99,4 +100,49 @@ Prompts to create a new wallet or import an existing private key. If `ZORA_PRIVA
 
 :::warning
 `--force` will overwrite the wallet at `~/.config/zora/wallet.json`. If that wallet owns a Zora agent, its smart wallet becomes unreachable — use a separate wallet file instead.
+:::
+
+### Connect an existing account
+
+```bash
+npx @zoralabs/cli wallet connect
+```
+
+Connect a Zora account you already have (created on the web or mobile app) so the CLI can act as it. Paste the private key that controls the account — export it from Zora's wallet settings (Privy). The CLI derives the owner EOA, **auto-discovers the account's smart wallet on-chain** (no address to look up), verifies the key owns it, and saves both to `~/.config/zora/wallet.json`. After connecting, `buy` / `sell` / `coin create` and the social commands act as your real account.
+
+This is the fix for "found my EOA but not my smart wallet": [`setup`](/commands/setup) and `wallet configure` (interactive import) only store the bare EOA, so they trade from the key directly rather than your Zora account. See [wallet modes](/guides/wallet-modes) for how the connected account maps to smart wallet mode.
+
+#### Options
+
+| Flag                       | Description                                                          |
+| -------------------------- | -------------------------------------------------------------------- |
+| `--key <key>`              | Private key (hex) — alternative to the positional argument or prompt |
+| `--smart-wallet <address>` | Smart wallet (account) address — overrides on-chain auto-discovery   |
+| `--force`                  | Overwrite an already-configured wallet without prompting             |
+| `--yes`                    | Skip interactive prompts (requires the key as an argument)           |
+| `--json`                   | Machine-readable JSON output                                         |
+
+:::tip
+Pass `--smart-wallet <address>` to override discovery when the account has a non-standard owner set (otherwise the smart wallet is derived deterministically from the owner key).
+:::
+
+#### JSON output
+
+```bash
+npx @zoralabs/cli wallet connect --key 0x... --yes --json
+```
+
+`discovered` is `true` when the smart wallet was found by on-chain prediction, and `false` when you supplied it via `--smart-wallet`:
+
+```json
+{
+  "smartWalletAddress": "0x1111111111111111111111111111111111111111",
+  "ownerAddress": "0xb4a06BdD9e0E60FFE22E4E7590842bfD2069034E",
+  "path": "~/.config/zora/wallet.json",
+  "discovered": true
+}
+```
+
+:::warning
+This stores the private key at `~/.config/zora/wallet.json`. Keep that file safe and backed up — anyone with the key has full access to the account. Fund the smart wallet with ETH or USDC on Base to start trading.
 :::

--- a/cli-docs/docs/pages/guides/wallet-modes.mdx
+++ b/cli-docs/docs/pages/guides/wallet-modes.mdx
@@ -2,16 +2,20 @@
 
 The Zora CLI operates in one of two modes, depending on whether a smart wallet is configured. The commands and flags are identical in both — only the wallet that holds and spends your funds, and the way transactions are sent, differ.
 
-| Mode             | Wallet that holds funds        | Created by                        |
-| ---------------- | ------------------------------ | --------------------------------- |
-| **EOA**          | Your private-key account (EOA) | [`setup`](/commands/setup)        |
-| **Smart wallet** | A Coinbase Smart Wallet        | [`agent create`](/commands/agent) |
+| Mode             | Wallet that holds funds        | Created by                                                                                                                             |
+| ---------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **EOA**          | Your private-key account (EOA) | [`setup`](/commands/setup)                                                                                                             |
+| **Smart wallet** | A Coinbase Smart Wallet        | [`agent create`](/commands/agent) (new account) or [`wallet connect`](/commands/wallet#connect-an-existing-account) (existing account) |
 
 ## How the mode is selected
 
 The CLI always resolves your private-key account first — that's the signer. It then looks for a smart wallet address, from the `ZORA_SMART_WALLET_ADDRESS` environment variable or the `smartWalletAddress` field in `~/.config/zora/wallet.json`. If one is found, commands operate **through the smart wallet**. If not, they run in **EOA mode**.
 
-It is not a human-versus-agent distinction — it is simply whether a smart wallet is configured. Running [`agent create`](/commands/agent) is the path that provisions one, but once it exists, the normal commands drive it like any other wallet.
+It is not a human-versus-agent distinction — it is simply whether a smart wallet is configured. Two paths provision one: [`agent create`](/commands/agent) stands up a brand-new Zora account, while [`wallet connect`](/commands/wallet#connect-an-existing-account) connects an account you **already** have (from the web or mobile app) by importing its key and auto-discovering its smart wallet on-chain. Either way, once the smart wallet is configured the normal commands drive it like any other wallet.
+
+:::warning
+[`setup`](/commands/setup) and `wallet configure` (interactive import) store only the bare **EOA**, so they run in EOA mode — they won't act as an existing Zora account even if the imported key controls one. To drive an existing account, use [`wallet connect`](/commands/wallet#connect-an-existing-account) instead, which discovers and configures its smart wallet.
+:::
 
 ## What changes between modes
 
@@ -25,4 +29,4 @@ The day-to-day commands are the same — `buy --eth`, `sell --percent`, `send --
 
 A Zora profile, creator coin, posts, and DMs all live on the smart wallet — that's the account shown on zora.co. The EOA is only the owner key that signs for it.
 
-EOA mode is fine for trading on its own, but it isn't a social identity. To have a profile, post, or send and receive DMs, operate as the smart wallet — which is what [`agent create`](/commands/agent) sets up.
+EOA mode is fine for trading on its own, but it isn't a social identity. To have a profile, post, or send and receive DMs, operate as the smart wallet — either stand up a new one with [`agent create`](/commands/agent), or connect an account you already have with [`wallet connect`](/commands/wallet#connect-an-existing-account).

--- a/cli-docs/vocs.config.ts
+++ b/cli-docs/vocs.config.ts
@@ -239,7 +239,16 @@ export default defineConfig({
         { text: "claim", link: "/commands/claim" },
         { text: "pay", link: "/commands/pay" },
         { text: "comment", link: "/commands/comment" },
-        { text: "create", link: "/commands/create" },
+        {
+          text: "coin",
+          link: "/commands/coin",
+          items: [
+            { text: "coin create", link: "/commands/coin#coin-create" },
+            { text: "coin edit", link: "/commands/coin#coin-edit" },
+            { text: "coin hide", link: "/commands/coin#coin-hide" },
+            { text: "coin unhide", link: "/commands/coin#coin-unhide" },
+          ],
+        },
         { text: "balance", link: "/commands/balance" },
         {
           text: "profile",
@@ -258,7 +267,16 @@ export default defineConfig({
         },
         { text: "auth", link: "/commands/auth" },
         { text: "setup", link: "/commands/setup" },
-        { text: "wallet", link: "/commands/wallet" },
+        {
+          text: "wallet",
+          link: "/commands/wallet",
+          items: [
+            {
+              text: "wallet connect",
+              link: "/commands/wallet#connect-an-existing-account",
+            },
+          ],
+        },
         {
           text: "agent",
           link: "/commands/agent",


### PR DESCRIPTION
Syncs the public mirror with the latest `zora-protocol-private` main.

This carries one content change — the CLI docs update from [zora-protocol-private#1903](https://github.com/ourzora/zora-protocol-private/pull/1903):

- New `cli-docs/docs/pages/commands/coin.mdx` documenting `coin create` / `coin edit` / `coin hide` / `coin unhide`
- `wallet connect` added to `commands/wallet.mdx`
- `commands/create.mdx` converted to a deprecation stub pointing at `coin create`
- Wallet Modes guide updated (smart-wallet mode reachable via `agent create` or `wallet connect`)
- Sidebar updated (`coin` group + `wallet connect`)

Merging triggers the CLI docs site rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)